### PR TITLE
[bug] Add example to nginx.conf for basic sampling

### DIFF
--- a/nginx-tracing/nginx.conf
+++ b/nginx-tracing/nginx.conf
@@ -11,6 +11,7 @@ http {
     datadog_agent_host localhost; # IP address or hostname of agent
     datadog_agent_port 8129;
     datadog_service_name nginx;
+    datadog_sample_rate 1.0;
 
     server {
         listen       80;


### PR DESCRIPTION
Adds `datadog_sample_rate` to the example nginx config