### PR TITLE
Update status badge now that repo is public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/DataDog/dd-opentracing-cpp/tree/master.svg?style=svg&circle-token=ad1c0acf298d39a594751ac9eb76ea92243e5fe3)](https://circleci.com/gh/DataDog/dd-opentracing-cpp/tree/master)
+[![CircleCI](https://circleci.com/gh/DataDog/dd-opentracing-cpp/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-opentracing-cpp/tree/master)
 
 # Datadog OpenTracing C++ Client
 


### PR DESCRIPTION
Old badge API key has already been revoked before repo publication.