### PR TITLE
[bug] Existing samples dropped. Let them trace.

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -49,15 +49,19 @@ SampleProvider ConstantRateSampler(double rate) {
           return true;
         }
 
-        if (context.id() == context.trace_id()) {
-          // A new trace, so a decision needs to be made.
-          uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
-          if (hashed_id < max_trace_id) {
-            // Chosen for sampling. Add mark to context and return.
-            context.setBaggageItem(sample_type_baggage_key, "ConstantRateSampler");
-            return true;
-          }
+        if (context.id() != context.trace_id()) {
+          // Permit existing traces. Sampling decision was made upstream.
+          return true;
         }
+
+        // A new trace, so a sampling decision needs to be made.
+        uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
+        if (hashed_id < max_trace_id) {
+          // Chosen for sampling. Add mark to context and return.
+          context.setBaggageItem(sample_type_baggage_key, "ConstantRateSampler");
+          return true;
+        }
+
         // Not chosen for sampling.
         return false;
       },


### PR DESCRIPTION
When a trace was started upstream and hit the new sampling code, it would get dropped - it was only making decisions about new traces and returning `false` for ones that weren't new.

This change makes it return `true` when a trace was started upstream.