### PR TITLE
[bug] Existing traces were dropped. Apply sample rate for all traces.

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -49,14 +49,12 @@ SampleProvider ConstantRateSampler(double rate) {
           return true;
         }
 
-        if (context.id() == context.trace_id()) {
-          // A new trace, so a decision needs to be made.
-          uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
-          if (hashed_id < max_trace_id) {
-            // Chosen for sampling. Add mark to context and return.
-            context.setBaggageItem(sample_type_baggage_key, "ConstantRateSampler");
-            return true;
-          }
+        // Apply the sample rate to all traces, new and existing (extracted from upstream).
+        uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
+        if (hashed_id < max_trace_id) {
+          // Chosen for sampling. Add mark to context and return.
+          context.setBaggageItem(sample_type_baggage_key, "ConstantRateSampler");
+          return true;
         }
         // Not chosen for sampling.
         return false;


### PR DESCRIPTION
When a trace was started upstream and hit the new sampling code, it would get dropped - it was only making decisions about new traces and returning false for ones that weren't new.

This change makes it apply the configured rate when a trace was started upstream.
That means the trace wouldn't be submitted to the trace agent. However, it still gets "injected" downstream. Is that the right behaviour for existing traces, or should downstream tracing also be suppressed?

The alternative is #29, just letting the original sampling decision made upstream be definitive, capturing data and writing it, and also injecting downstream.