### PR TITLE
Seperate Span data from OT Span behaviour

### DIFF
--- a/src/span.h
+++ b/src/span.h
@@ -11,44 +11,44 @@ namespace datadog {
 namespace opentracing {
 
 class Tracer;
-template <class Span>
 class SpanBuffer;
+class SpanData;
 typedef std::function<uint64_t()> IdProvider;  // See tracer.h
 
-template <class Span>
-using Trace = std::unique_ptr<std::vector<std::unique_ptr<Span>>>;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 
 // Contains data that describes a Span.
 struct SpanData {
   ~SpanData() = default;
 
-  friend std::unique_ptr<SpanData> makeSpanData(int64_t span_id, uint64_t trace_id,
-                                                uint64_t parent_id, std::string service,
-                                                std::string type, std::string name,
-                                                ot::string_view resource, int64_t start);
+  friend std::unique_ptr<SpanData> makeSpanData(std::string type, std::string service,
+                                                ot::string_view resource, std::string name,
+                                                uint64_t trace_id, int64_t span_id,
+                                                uint64_t parent_id, int64_t start);
 
   friend std::unique_ptr<SpanData> stubSpanData();
 
- private:  // Can only be created in a unique_ptr.
-  SpanData(uint64_t span_id, uint64_t trace_id, uint64_t parent_id, std::string service,
-           std::string type, std::string name, ot::string_view resource, int64_t start);
+ protected:  // Can only be created in a unique_ptr (or in a subclassed test class).
+  SpanData(std::string type, std::string service, ot::string_view resource, std::string name,
+           uint64_t trace_id, uint64_t span_id, uint64_t parent_id, int64_t start,
+           int64_t duration, int32_t error);
   SpanData();
-  SpanData(const SpanData &) = delete;
+  SpanData(const SpanData &) = default;
   SpanData &operator=(const SpanData &) = delete;
   SpanData(const SpanData &&) = delete;
   SpanData &operator=(const SpanData &&) = delete;
 
  public:
-  uint64_t span_id;
-  uint64_t trace_id;
-  uint64_t parent_id;
-  std::string name;
+  std::string type;
   std::string service;
   std::string resource;
-  std::string type;
-  int32_t error;
+  std::string name;
+  uint64_t trace_id;
+  uint64_t span_id;
+  uint64_t parent_id;
   int64_t start;
   int64_t duration;
+  int32_t error;
   std::unordered_map<std::string, std::string> meta;  // Aka, tags.
 
   uint64_t traceId() const;
@@ -62,7 +62,7 @@ struct SpanData {
 class Span : public ot::Span {
  public:
   // Creates a new Span.
-  Span(std::shared_ptr<const Tracer> tracer, std::shared_ptr<SpanBuffer<SpanData>> buffer,
+  Span(std::shared_ptr<const Tracer> tracer, std::shared_ptr<SpanBuffer> buffer,
        TimeProvider get_time, uint64_t span_id, uint64_t trace_id, uint64_t parent_id,
        SpanContext context, TimePoint start_time, std::string span_service, std::string span_type,
        std::string span_name, ot::string_view resource);
@@ -96,7 +96,7 @@ class Span : public ot::Span {
 
   // Set in constructor initializer:
   std::shared_ptr<const Tracer> tracer_;
-  std::shared_ptr<SpanBuffer<SpanData>> buffer_;
+  std::shared_ptr<SpanBuffer> buffer_;
   TimeProvider get_time_;
   SpanContext context_;
   TimePoint start_time_;

--- a/src/span.h
+++ b/src/span.h
@@ -16,19 +16,58 @@ class SpanBuffer;
 typedef std::function<uint64_t()> IdProvider;  // See tracer.h
 
 template <class Span>
-using Trace = std::unique_ptr<std::vector<Span>>;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<Span>>>;
+
+// Contains data that describes a Span.
+struct SpanData {
+  ~SpanData() = default;
+
+  friend std::unique_ptr<SpanData> makeSpanData(int64_t span_id, uint64_t trace_id,
+                                                uint64_t parent_id, std::string service,
+                                                std::string type, std::string name,
+                                                ot::string_view resource, int64_t start);
+
+  friend std::unique_ptr<SpanData> stubSpanData();
+
+ private:  // Can only be created in a unique_ptr.
+  SpanData(uint64_t span_id, uint64_t trace_id, uint64_t parent_id, std::string service,
+           std::string type, std::string name, ot::string_view resource, int64_t start);
+  SpanData();
+  SpanData(const SpanData &) = delete;
+  SpanData &operator=(const SpanData &) = delete;
+  SpanData(const SpanData &&) = delete;
+  SpanData &operator=(const SpanData &&) = delete;
+
+ public:
+  uint64_t span_id;
+  uint64_t trace_id;
+  uint64_t parent_id;
+  std::string name;
+  std::string service;
+  std::string resource;
+  std::string type;
+  int32_t error;
+  int64_t start;
+  int64_t duration;
+  std::unordered_map<std::string, std::string> meta;  // Aka, tags.
+
+  uint64_t traceId() const;
+  uint64_t spanId() const;
+
+  MSGPACK_DEFINE_MAP(name, service, resource, type, start, duration, meta, span_id, trace_id,
+                     parent_id, error);
+};
 
 // A Span, a component of a trace, a single instrumented event.
 class Span : public ot::Span {
  public:
-  // Creates a new Span, usually called by Tracer::StartSpanWithOptions.
-  Span(std::shared_ptr<const Tracer> tracer, std::shared_ptr<SpanBuffer<Span>> buffer,
+  // Creates a new Span.
+  Span(std::shared_ptr<const Tracer> tracer, std::shared_ptr<SpanBuffer<SpanData>> buffer,
        TimeProvider get_time, uint64_t span_id, uint64_t trace_id, uint64_t parent_id,
        SpanContext context, TimePoint start_time, std::string span_service, std::string span_type,
-       std::string span_name, ot::string_view resource, const ot::StartSpanOptions &options);
+       std::string span_name, ot::string_view resource);
 
   Span() = delete;
-  Span(Span &&other);
   ~Span() override;
 
   // Finishes and records the span.
@@ -52,33 +91,18 @@ class Span : public ot::Span {
   uint64_t spanId() const;
 
  private:
-  std::shared_ptr<const Tracer> tracer_;
-  TimeProvider get_time_;
-  std::shared_ptr<SpanBuffer<Span>> buffer_;
-  TimePoint start_time_;
-  std::atomic<bool> is_finished_{false};
   std::mutex mutex_;
+  std::atomic<bool> is_finished_{false};
 
-  // An exception to the naming convention is made here because the variable names themselves are
-  // used by msgpack as dictionary keys.
-  std::string name;
-  std::string service;
-  std::string resource;
-  std::string type;
-  // TODO[willgittoes-dd]: Consider making the ID members const.
-  uint64_t span_id;
-  uint64_t trace_id;
-  uint64_t parent_id;
-  int32_t error;
-  int64_t start;
-  int64_t duration;
-  std::unordered_map<std::string, std::string> meta;  // Aka, tags.
-
+  // Set in constructor initializer:
+  std::shared_ptr<const Tracer> tracer_;
+  std::shared_ptr<SpanBuffer<SpanData>> buffer_;
+  TimeProvider get_time_;
   SpanContext context_;
+  TimePoint start_time_;
 
- public:
-  MSGPACK_DEFINE_MAP(name, service, resource, type, start, duration, meta, span_id, trace_id,
-                     parent_id, error);
+  // Set in constructor initializer, depends on previous constructor initializer-set members:
+  std::unique_ptr<SpanData> span_;
 };
 
 }  // namespace opentracing

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -22,19 +22,19 @@ void WritingSpanBuffer<Span>::registerSpan(const Span& span) {
 }
 
 template <class Span>
-void WritingSpanBuffer<Span>::finishSpan(Span&& span) {
+void WritingSpanBuffer<Span>::finishSpan(std::unique_ptr<Span> span) {
   std::lock_guard<std::mutex> lock_guard{mutex_};
-  auto trace_iter = traces_.find(span.traceId());
+  auto trace_iter = traces_.find(span->traceId());
   if (trace_iter == traces_.end()) {
     std::cerr << "Missing trace for finished span" << std::endl;
     return;
   }
   auto& trace = trace_iter->second;
-  if (trace.all_spans.find(span.spanId()) == trace.all_spans.end()) {
+  if (trace.all_spans.find(span->spanId()) == trace.all_spans.end()) {
     std::cerr << "A Span that was not registered was submitted to WritingSpanBuffer" << std::endl;
     return;
   }
-  trace.finished_spans->emplace_back(std::move(span));
+  trace.finished_spans->push_back(std::move(span));
   if (trace.finished_spans->size() == trace.all_spans.size()) {
     writer_->write(std::move(trace.finished_spans));
     traces_.erase(trace_iter);
@@ -42,7 +42,7 @@ void WritingSpanBuffer<Span>::finishSpan(Span&& span) {
 }
 
 // Make sure we generate code for a Span-buffering SpanBuffer.
-template class WritingSpanBuffer<Span>;
+template class WritingSpanBuffer<SpanData>;
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -14,11 +14,12 @@ class Span;
 template <class Span>
 class Writer;
 template <class Span>
-using Trace = std::unique_ptr<std::vector<Span>>;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<Span>>>;
 
 template <class Span>
 struct PendingTrace {
-  PendingTrace() : finished_spans(std::make_unique<std::vector<Span>>()), all_spans() {}
+  PendingTrace()
+      : finished_spans(Trace<Span>{new std::vector<std::unique_ptr<Span>>()}), all_spans() {}
 
   Trace<Span> finished_spans;
   std::unordered_set<uint64_t> all_spans;
@@ -31,7 +32,7 @@ class SpanBuffer {
   SpanBuffer() {}
   virtual ~SpanBuffer() {}
   virtual void registerSpan(const Span& span) = 0;
-  virtual void finishSpan(Span&& span) = 0;
+  virtual void finishSpan(std::unique_ptr<Span> span) = 0;
 };
 
 // A SpanBuffer that sends completed traces to a Writer.
@@ -41,7 +42,7 @@ class WritingSpanBuffer : public SpanBuffer<Span> {
   WritingSpanBuffer(std::shared_ptr<Writer<Span>> writer);
 
   void registerSpan(const Span& span) override;
-  void finishSpan(Span&& span) override;
+  void finishSpan(std::unique_ptr<Span> span) override;
 
  private:
   std::shared_ptr<Writer<Span>> writer_;

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -18,13 +18,13 @@ uint64_t getId() {
 
 Tracer::Tracer(TracerOptions options)
     : Tracer(options,
-             std::shared_ptr<SpanBuffer<Span>>{
-                 new WritingSpanBuffer<Span>{std::make_shared<AgentWriter<Span>>(
+             std::shared_ptr<SpanBuffer<SpanData>>{
+                 new WritingSpanBuffer<SpanData>{std::make_shared<AgentWriter<SpanData>>(
                      options.agent_host, options.agent_port,
                      std::chrono::milliseconds(llabs(options.write_period_ms)))}},
              getRealTime, getId, ConstantRateSampler(options.sample_rate)) {}
 
-Tracer::Tracer(TracerOptions options, std::shared_ptr<SpanBuffer<Span>> buffer,
+Tracer::Tracer(TracerOptions options, std::shared_ptr<SpanBuffer<SpanData>> buffer,
                TimeProvider get_time, IdProvider get_id, SampleProvider sampler)
     : opts_(options),
       buffer_(std::move(buffer)),
@@ -56,7 +56,7 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
     auto span = std::unique_ptr<ot::Span>{new Span{shared_from_this(), buffer_, get_time_, span_id,
                                                    trace_id, parent_id, std::move(span_context),
                                                    get_time_(), opts_.service, opts_.type,
-                                                   operation_name, operation_name, options}};
+                                                   operation_name, operation_name}};
     sampler_.tag(span);
     return std::move(span);
   } else {

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -18,14 +18,13 @@ uint64_t getId() {
 
 Tracer::Tracer(TracerOptions options)
     : Tracer(options,
-             std::shared_ptr<SpanBuffer<SpanData>>{
-                 new WritingSpanBuffer<SpanData>{std::make_shared<AgentWriter<SpanData>>(
-                     options.agent_host, options.agent_port,
-                     std::chrono::milliseconds(llabs(options.write_period_ms)))}},
+             std::shared_ptr<SpanBuffer>{new WritingSpanBuffer{std::make_shared<AgentWriter>(
+                 options.agent_host, options.agent_port,
+                 std::chrono::milliseconds(llabs(options.write_period_ms)))}},
              getRealTime, getId, ConstantRateSampler(options.sample_rate)) {}
 
-Tracer::Tracer(TracerOptions options, std::shared_ptr<SpanBuffer<SpanData>> buffer,
-               TimeProvider get_time, IdProvider get_id, SampleProvider sampler)
+Tracer::Tracer(TracerOptions options, std::shared_ptr<SpanBuffer> buffer, TimeProvider get_time,
+               IdProvider get_id, SampleProvider sampler)
     : opts_(options),
       buffer_(std::move(buffer)),
       get_time_(get_time),

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -18,7 +18,7 @@ namespace opentracing {
 
 template <class Span>
 class Writer;
-class Span;
+class SpanData;
 template <class Span>
 class SpanBuffer;
 
@@ -33,8 +33,8 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   Tracer(TracerOptions options);
 
   // Creates a Tracer by copying the given options and injecting the given dependencies.
-  Tracer(TracerOptions options, std::shared_ptr<SpanBuffer<Span>> buffer, TimeProvider get_time,
-         IdProvider get_id, SampleProvider sample);
+  Tracer(TracerOptions options, std::shared_ptr<SpanBuffer<SpanData>> buffer,
+         TimeProvider get_time, IdProvider get_id, SampleProvider sample);
 
   Tracer() = delete;
 
@@ -66,7 +66,7 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
 
   const TracerOptions opts_;
   // Keeps finished spans until their entire trace is finished.
-  std::shared_ptr<SpanBuffer<Span>> buffer_;
+  std::shared_ptr<SpanBuffer<SpanData>> buffer_;
   TimeProvider get_time_;
   IdProvider get_id_;
   SampleProvider sampler_;

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -16,10 +16,8 @@ namespace ot = opentracing;
 namespace datadog {
 namespace opentracing {
 
-template <class Span>
 class Writer;
 class SpanData;
-template <class Span>
 class SpanBuffer;
 
 // The interface for providing IDs to spans and traces.
@@ -33,8 +31,8 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   Tracer(TracerOptions options);
 
   // Creates a Tracer by copying the given options and injecting the given dependencies.
-  Tracer(TracerOptions options, std::shared_ptr<SpanBuffer<SpanData>> buffer,
-         TimeProvider get_time, IdProvider get_id, SampleProvider sample);
+  Tracer(TracerOptions options, std::shared_ptr<SpanBuffer> buffer, TimeProvider get_time,
+         IdProvider get_id, SampleProvider sample);
 
   Tracer() = delete;
 
@@ -66,7 +64,7 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
 
   const TracerOptions opts_;
   // Keeps finished spans until their entire trace is finished.
-  std::shared_ptr<SpanBuffer<SpanData>> buffer_;
+  std::shared_ptr<SpanBuffer> buffer_;
   TimeProvider get_time_;
   IdProvider get_id_;
   SampleProvider sampler_;

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -192,7 +192,7 @@ bool AgentWriter<Span>::postTraces(std::unique_ptr<Handle> &handle, std::strings
 }
 
 // Make sure we generate code for a Span-writing Writer.
-template class AgentWriter<Span>;
+template class AgentWriter<SpanData>;
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -18,17 +18,14 @@ const std::vector<std::chrono::milliseconds> default_retry_periods{
 const long default_timeout_ms = 2000L;
 }  // namespace
 
-template <class Span>
-AgentWriter<Span>::AgentWriter(std::string host, uint32_t port,
-                               std::chrono::milliseconds write_period)
+AgentWriter::AgentWriter(std::string host, uint32_t port, std::chrono::milliseconds write_period)
     : AgentWriter(std::unique_ptr<Handle>{new CurlHandle{}}, config::tracer_version, write_period,
                   max_queued_traces, default_retry_periods, host, port){};
 
-template <class Span>
-AgentWriter<Span>::AgentWriter(std::unique_ptr<Handle> handle, std::string tracer_version,
-                               std::chrono::milliseconds write_period, size_t max_queued_traces,
-                               std::vector<std::chrono::milliseconds> retry_periods,
-                               std::string host, uint32_t port)
+AgentWriter::AgentWriter(std::unique_ptr<Handle> handle, std::string tracer_version,
+                         std::chrono::milliseconds write_period, size_t max_queued_traces,
+                         std::vector<std::chrono::milliseconds> retry_periods, std::string host,
+                         uint32_t port)
     : tracer_version_(tracer_version),
       write_period_(write_period),
       max_queued_traces_(max_queued_traces),
@@ -37,9 +34,7 @@ AgentWriter<Span>::AgentWriter(std::unique_ptr<Handle> handle, std::string trace
   startWriting(std::move(handle));
 }
 
-template <class Span>
-void AgentWriter<Span>::setUpHandle(std::unique_ptr<Handle> &handle, std::string host,
-                                    uint32_t port) {
+void AgentWriter::setUpHandle(std::unique_ptr<Handle> &handle, std::string host, uint32_t port) {
   // Some options are the same for all actions, set them here.
   // Set the agent URI.
   std::stringstream agent_uri;
@@ -59,13 +54,9 @@ void AgentWriter<Span>::setUpHandle(std::unique_ptr<Handle> &handle, std::string
                       {"Datadog-Meta-Tracer-Version", tracer_version_}});
 }  // namespace opentracing
 
-template <class Span>
-AgentWriter<Span>::~AgentWriter() {
-  stop();
-}
+AgentWriter::~AgentWriter() { stop(); }
 
-template <class Span>
-void AgentWriter<Span>::stop() {
+void AgentWriter::stop() {
   {
     std::unique_lock<std::mutex> lock(mutex_);
     if (stop_writing_) {
@@ -77,8 +68,7 @@ void AgentWriter<Span>::stop() {
   worker_->join();
 }
 
-template <class Span>
-void AgentWriter<Span>::write(Trace<Span> trace) {
+void AgentWriter::write(Trace trace) {
   std::unique_lock<std::mutex> lock(mutex_);
   if (stop_writing_) {
     return;
@@ -89,8 +79,7 @@ void AgentWriter<Span>::write(Trace<Span> trace) {
   traces_.push_back(std::move(trace));
 };
 
-template <class Span>
-void AgentWriter<Span>::startWriting(std::unique_ptr<Handle> handle) {
+void AgentWriter::startWriting(std::unique_ptr<Handle> handle) {
   // Start worker that sends Traces to agent.
   // We can capture 'this' because destruction of this stops the thread and the lambda.
   worker_ = std::make_unique<std::thread>(
@@ -118,8 +107,7 @@ void AgentWriter<Span>::startWriting(std::unique_ptr<Handle> handle) {
             traces_.clear();
           }  // lock on mutex_ ends.
           // Send spans, not in critical period.
-          retryFiniteOnFail(
-              [&]() { return AgentWriter<Span>::postTraces(handle, buffer, num_traces); });
+          retryFiniteOnFail([&]() { return AgentWriter::postTraces(handle, buffer, num_traces); });
           // Let thread calling 'flush' that we're done flushing.
           {
             std::unique_lock<std::mutex> lock(mutex_);
@@ -131,8 +119,7 @@ void AgentWriter<Span>::startWriting(std::unique_ptr<Handle> handle) {
       std::move(handle));
 }
 
-template <class Span>
-void AgentWriter<Span>::flush() try {
+void AgentWriter::flush() try {
   std::unique_lock<std::mutex> lock(mutex_);
   flush_worker_ = true;
   condition_.notify_all();
@@ -141,8 +128,7 @@ void AgentWriter<Span>::flush() try {
 } catch (const std::bad_alloc &) {
 }
 
-template <class Span>
-void AgentWriter<Span>::retryFiniteOnFail(std::function<bool()> f) const {
+void AgentWriter::retryFiniteOnFail(std::function<bool()> f) const {
   for (std::chrono::milliseconds backoff : retry_periods_) {
     if (f()) {
       return;
@@ -160,9 +146,8 @@ void AgentWriter<Span>::retryFiniteOnFail(std::function<bool()> f) const {
   f();  // Final try after final sleep.
 }
 
-template <class Span>
-bool AgentWriter<Span>::postTraces(std::unique_ptr<Handle> &handle, std::stringstream &buffer,
-                                   size_t num_traces) try {
+bool AgentWriter::postTraces(std::unique_ptr<Handle> &handle, std::stringstream &buffer,
+                             size_t num_traces) try {
   handle->setHeaders({{"X-Datadog-Trace-Count", std::to_string(num_traces)}});
 
   // We have to set the size manually, because msgpack uses null characters.
@@ -190,9 +175,6 @@ bool AgentWriter<Span>::postTraces(std::unique_ptr<Handle> &handle, std::strings
   // Drop spans, but live to fight another day.
   return true;  // Don't attempt to retry.
 }
-
-// Make sure we generate code for a Span-writing Writer.
-template class AgentWriter<SpanData>;
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/writer.h
+++ b/src/writer.h
@@ -13,12 +13,10 @@
 namespace datadog {
 namespace opentracing {
 
-class Span;
-template <class Span>
-using Trace = std::unique_ptr<std::vector<std::unique_ptr<Span>>>;
+class SpanData;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 
 // Takes Traces and writes them (eg. sends them to Datadog).
-template <class Span>
 class Writer {
  public:
   Writer() {}
@@ -26,12 +24,11 @@ class Writer {
   virtual ~Writer() {}
 
   // Writes the given Trace.
-  virtual void write(Trace<Span> trace) = 0;
+  virtual void write(Trace trace) = 0;
 };
 
 // A Writer that sends Traces (collections of Spans) to a Datadog agent.
-template <class Span>
-class AgentWriter : public Writer<Span> {
+class AgentWriter : public Writer {
  public:
   // Creates an AgentWriter that uses curl to send Traces to a Datadog agent. May throw a
   // runtime_exception.
@@ -45,7 +42,7 @@ class AgentWriter : public Writer<Span> {
   // Does not flush on destruction, buffered traces may be lost. Stops all threads.
   ~AgentWriter() override;
 
-  void write(Trace<Span> trace) override;
+  void write(Trace trace) override;
 
   // Send all buffered Traces to the destination now. Will block until sending is complete. This
   // isn't on the main Writer API because real code should not need to call this.
@@ -90,7 +87,7 @@ class AgentWriter : public Writer<Span> {
   // If set to true, flushes worker (which sets it false again). Locked by mutex_;
   bool flush_worker_ = false;
   // Multiple producer (potentially), single consumer. Locked by mutex_.
-  std::deque<Trace<Span>> traces_;
+  std::deque<Trace> traces_;
 };
 
 }  // namespace opentracing

--- a/src/writer.h
+++ b/src/writer.h
@@ -15,7 +15,7 @@ namespace opentracing {
 
 class Span;
 template <class Span>
-using Trace = std::unique_ptr<std::vector<Span>>;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<Span>>>;
 
 // Takes Traces and writes them (eg. sends them to Datadog).
 template <class Span>

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -76,7 +76,7 @@ COPY ./test/integration/nginx/nginx.conf /usr/local/nginx/conf/nginx.conf
 
 # Get Wiremock
 ADD http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.18.0/wiremock-standalone-2.18.0.jar wiremock-standalone-2.18.0.jar
-RUN printf "#!/bin/bash\nset -x\njava -jar $(pwd)/wiremock-standalone-2.18.0.jar \"\$@\"\n" > /usr/local/bin/wiremock && \
+RUN printf '#!/bin/bash\nset -x\njava -jar '"$(pwd)/wiremock-standalone-2.18.0.jar \"\$@\"\n" > /usr/local/bin/wiremock && \
   chmod a+x /usr/local/bin/wiremock
 
 COPY ./test/integration/nginx/nginx_integration_test.sh ./nginx_integration_test.sh

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -32,7 +32,7 @@ go get github.com/jakm/msgpack-cli
 if ! which wiremock >/dev/null
 then
   wget  http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.18.0/wiremock-standalone-2.18.0.jar
-  printf "#!/bin/bash\nset -x\njava -jar $(pwd)/wiremock-standalone-2.18.0.jar \"\$@\"\n" > /usr/local/bin/wiremock && \
+  printf '#!/bin/bash\nset -x\njava -jar '"$(pwd)/wiremock-standalone-2.18.0.jar \"\$@\"\n" > /usr/local/bin/wiremock && \
   chmod a+x /usr/local/bin/wiremock
 fi
 # Start wiremock in background

--- a/test/span_buffer_test.cpp
+++ b/test/span_buffer_test.cpp
@@ -1,5 +1,4 @@
 #include "../src/span_buffer.h"
-#include "../src/span_buffer.cpp"  // Otherwise the compiler won't generate WritingSpanBuffer<SpanInfo> for us.
 #include "mocks.h"
 
 #define CATCH_CONFIG_MAIN
@@ -7,67 +6,75 @@
 using namespace datadog::opentracing;
 
 TEST_CASE("span buffer") {
-  auto writer_ptr = std::make_shared<MockWriter<SpanInfo>>();
-  MockWriter<SpanInfo>* writer = writer_ptr.get();
-  WritingSpanBuffer<SpanInfo> buffer{writer_ptr};
+  auto writer_ptr = std::make_shared<MockWriter>();
+  MockWriter* writer = writer_ptr.get();
+  WritingSpanBuffer buffer{writer_ptr};
 
   SECTION("can write a single-span trace") {
-    SpanInfo span{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
-    buffer.registerSpan(span);
+    auto span = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420, 420, 0,
+                                               123, 456, 0);
+    buffer.registerSpan(*span);
     buffer.finishSpan(std::move(span));
     REQUIRE(writer->traces.size() == 1);
     REQUIRE(writer->traces[0].size() == 1);
-    auto result = writer->traces[0][0];
-    REQUIRE(result.name == "name");
-    REQUIRE(result.service == "service");
-    REQUIRE(result.resource == "resource");
-    REQUIRE(result.type == "type");
-    REQUIRE(result.span_id == 420);
-    REQUIRE(result.trace_id == 420);
-    REQUIRE(result.parent_id == 0);
-    REQUIRE(result.error == 0);
-    REQUIRE(result.start == 123);
-    REQUIRE(result.duration == 456);
-    REQUIRE(result.meta == std::unordered_map<std::string, std::string>{});
+    auto& result = writer->traces[0][0];
+    REQUIRE(result->name == "name");
+    REQUIRE(result->service == "service");
+    REQUIRE(result->resource == "resource");
+    REQUIRE(result->type == "type");
+    REQUIRE(result->span_id == 420);
+    REQUIRE(result->trace_id == 420);
+    REQUIRE(result->parent_id == 0);
+    REQUIRE(result->error == 0);
+    REQUIRE(result->start == 123);
+    REQUIRE(result->duration == 456);
+    REQUIRE(result->meta == std::unordered_map<std::string, std::string>{});
   }
 
   SECTION("can write a multi-span trace") {
-    SpanInfo rootSpan{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
-    buffer.registerSpan(rootSpan);
-    SpanInfo childSpan{"name", "service", "resource", "type", 421, 420, 0, 0, 124, 455, {}};
-    buffer.registerSpan(childSpan);
+    auto rootSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420, 420,
+                                                   0, 123, 456, 0);
+    buffer.registerSpan(*rootSpan);
+    auto childSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                    421, 0, 124, 455, 0);
+    buffer.registerSpan(*childSpan);
     buffer.finishSpan(std::move(childSpan));
     buffer.finishSpan(std::move(rootSpan));
     REQUIRE(writer->traces.size() == 1);
     REQUIRE(writer->traces[0].size() == 2);
     // Although order doesn't actually matter.
-    REQUIRE(writer->traces[0][0].span_id == 421);
-    REQUIRE(writer->traces[0][1].span_id == 420);
+    REQUIRE(writer->traces[0][0]->span_id == 421);
+    REQUIRE(writer->traces[0][1]->span_id == 420);
   }
 
   SECTION("can write a multi-span trace, even if the root finishes before a child") {
-    SpanInfo rootSpan{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
-    buffer.registerSpan(rootSpan);
-    SpanInfo childSpan{"name", "service", "resource", "type", 421, 420, 0, 0, 124, 455, {}};
-    buffer.registerSpan(childSpan);
+    auto rootSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420, 420,
+                                                   0, 123, 456, 0);
+    buffer.registerSpan(*rootSpan);
+    auto childSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                    421, 0, 124, 455, 0);
+    buffer.registerSpan(*childSpan);
     buffer.finishSpan(std::move(rootSpan));
     buffer.finishSpan(std::move(childSpan));
     REQUIRE(writer->traces.size() == 1);
     REQUIRE(writer->traces[0].size() == 2);
     // Although order doesn't actually matter.
-    REQUIRE(writer->traces[0][0].span_id == 420);
-    REQUIRE(writer->traces[0][1].span_id == 421);
+    REQUIRE(writer->traces[0][0]->span_id == 420);
+    REQUIRE(writer->traces[0][1]->span_id == 421);
   }
 
   SECTION("doesn't write an unfinished trace") {
-    SpanInfo rootSpan{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
-    buffer.registerSpan(rootSpan);
-    SpanInfo childSpan{"name", "service", "resource", "type", 421, 420, 0, 0, 124, 455, {}};
-    buffer.registerSpan(childSpan);
+    auto rootSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420, 420,
+                                                   0, 123, 456, 0);
+    buffer.registerSpan(*rootSpan);
+    auto childSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                    421, 0, 124, 455, 0);
+    buffer.registerSpan(*childSpan);
     buffer.finishSpan(std::move(childSpan));
     REQUIRE(writer->traces.size() == 0);  // rootSpan still outstanding
-    SpanInfo childSpan2{"name", "service", "resource", "type", 422, 420, 0, 0, 125, 457, {}};
-    buffer.registerSpan(childSpan2);
+    auto childSpan2 = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                     422, 0, 125, 457, 0);
+    buffer.registerSpan(*childSpan2);
     buffer.finishSpan(std::move(rootSpan));
     // Root span finished, but *after* childSpan2 was registered, so childSpan2 still oustanding.
     REQUIRE(writer->traces.size() == 0);
@@ -83,31 +90,36 @@ TEST_CASE("span buffer") {
     std::streambuf* stderr = std::cerr.rdbuf(error_message.rdbuf());
 
     SECTION("not even a trace") {
-      SpanInfo rootSpan{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
+      auto rootSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                     420, 0, 123, 456, 0);
       buffer.finishSpan(std::move(rootSpan));
       REQUIRE(writer->traces.size() == 0);
     }
     SECTION("there's a trace but no startSpan call") {
-      SpanInfo rootSpan{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
-      buffer.registerSpan(rootSpan);
-      SpanInfo childSpan{"name", "service", "resource", "type", 421, 420, 0, 0, 124, 455, {}};
+      auto rootSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                     420, 0, 123, 456, 0);
+      buffer.registerSpan(*rootSpan);
+      auto childSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                      421, 0, 124, 455, 0);
       buffer.finishSpan(std::move(childSpan));
       buffer.finishSpan(std::move(rootSpan));
       REQUIRE(writer->traces.size() == 1);
       REQUIRE(writer->traces[0].size() == 1);  // Only rootSpan got written.
-      REQUIRE(writer->traces[0][0].span_id == 420);
+      REQUIRE(writer->traces[0][0]->span_id == 420);
     }
 
     std::cerr.rdbuf(stderr);  // Restore stderr.
   }
 
   SECTION("spans written after a trace is submitted just start a new trace") {
-    SpanInfo rootSpan{"name", "service", "resource", "type", 420, 420, 0, 0, 123, 456, {}};
-    buffer.registerSpan(rootSpan);
+    auto rootSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420, 420,
+                                                   0, 123, 456, 0);
+    buffer.registerSpan(*rootSpan);
     buffer.finishSpan(std::move(rootSpan));
     REQUIRE(writer->traces.size() == 1);
-    SpanInfo childSpan{"name", "service", "resource", "type", 421, 420, 0, 0, 123, 456, {}};
-    buffer.registerSpan(childSpan);
+    auto childSpan = std::make_unique<TestSpanData>("type", "service", "resource", "name", 420,
+                                                    421, 0, 123, 456, 0);
+    buffer.registerSpan(*childSpan);
     buffer.finishSpan(std::move(childSpan));
     REQUIRE(writer->traces.size() == 2);
   }
@@ -123,9 +135,9 @@ TEST_CASE("span buffer") {
             for (uint64_t span_id = trace_id; span_id < trace_id + 5; span_id++) {
               span_writers.emplace_back(
                   [&](uint64_t span_id) {
-                    SpanInfo span{"name", "service", "resource", "type", span_id, trace_id,
-                                  0,      0,         123,        456,    {}};
-                    buffer.registerSpan(span);
+                    auto span = std::make_unique<TestSpanData>(
+                        "type", "service", "resource", "name", trace_id, span_id, 0, 123, 456, 0);
+                    buffer.registerSpan(*span);
                   },
                   span_id);
             }
@@ -137,8 +149,8 @@ TEST_CASE("span buffer") {
             for (uint64_t span_id = trace_id; span_id < trace_id + 5; span_id++) {
               span_writers.emplace_back(
                   [&](uint64_t span_id) {
-                    SpanInfo span{"name", "service", "resource", "type", span_id, trace_id,
-                                  0,      0,         123,        456,    {}};
+                    auto span = std::make_unique<TestSpanData>(
+                        "type", "service", "resource", "name", trace_id, span_id, 0, 123, 456, 0);
                     buffer.finishSpan(std::move(span));
                   },
                   span_id);

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -18,8 +18,8 @@ TEST_CASE("tracer") {
   IdProvider get_id = [&id]() { return id++; };        // Mock ID provider.
   SampleProvider sampler = KeepAllSampler();
   TracerOptions tracer_options{"", 0, "service_name", "web"};
-  std::shared_ptr<Tracer> tracer{new Tracer{
-      tracer_options, std::shared_ptr<SpanBuffer<Span>>{buffer}, get_time, get_id, sampler}};
+  std::shared_ptr<Tracer> tracer{
+      new Tracer{tracer_options, std::shared_ptr<SpanBuffer>{buffer}, get_time, get_id, sampler}};
   const ot::StartSpanOptions span_options;
 
   SECTION("names spans correctly") {
@@ -27,11 +27,11 @@ TEST_CASE("tracer") {
     const ot::FinishSpanOptions finish_options;
     span->FinishWithOptions(finish_options);
 
-    auto result = buffer->traces[100].finished_spans->at(0);
-    REQUIRE(result.type == "web");
-    REQUIRE(result.service == "service_name");
-    REQUIRE(result.name == "/what_up");
-    REQUIRE(result.resource == "/what_up");
+    auto& result = buffer->traces[100].finished_spans->at(0);
+    REQUIRE(result->type == "web");
+    REQUIRE(result->service == "service_name");
+    REQUIRE(result->name == "/what_up");
+    REQUIRE(result->resource == "/what_up");
   }
 
   SECTION("spans receive id") {
@@ -39,9 +39,9 @@ TEST_CASE("tracer") {
     const ot::FinishSpanOptions finish_options;
     span->FinishWithOptions(finish_options);
 
-    auto result = buffer->traces[100].finished_spans->at(0);
-    REQUIRE(result.span_id == 100);
-    REQUIRE(result.trace_id == 100);
-    REQUIRE(result.parent_id == 0);
+    auto& result = buffer->traces[100].finished_spans->at(0);
+    REQUIRE(result->span_id == 100);
+    REQUIRE(result->trace_id == 100);
+    REQUIRE(result->parent_id == 0);
   }
 }


### PR DESCRIPTION
Moves span data (ids, names, tags, timing) to a simple struct class, separating it from the more complex OpenTracing Span implementation (that is now a wrapper for that struct).

This enforces a structural separation between data and OT-related behaviour. Specifically, this should in future prevent the kind of nasty bug I had before where a finished span awaiting writing kept invalid references to the tracer & buffer. 

It also means I could get rid of the template parameterisation for Buffer & Writer.

This fixes the nasty bug, of course :D 

Also changes the order of the fields in Span/SpanData to be more consistent.