### PR TITLE
Simplify CI, build shared plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ jobs:
           command: |
             rm -rf .build
             mkdir -p .build
-            mkdir -p /tmp/build
             cd .build
             cmake $CMAKE_ARGS ..
             make
+            cp libdd_opentracing_plugin.so /tmp/build
       - persist_to_workspace:
           root: /tmp/
           paths:
@@ -65,11 +65,9 @@ jobs:
           command: |
             rm -rf .build
             mkdir -p .build
-            mkdir -p /tmp/build
             cd .build
             cmake $CMAKE_ARGS ..
             make
-            cd .build
             ctest --output-on-failure
 
   test_tsan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,99 +3,21 @@ version: 2
 source_dependency_versions: &source_dependency_versions
   MSGPACK_VERSION: 3.0.1
   OPENTRACING_VERSION: 1.5.0
-  NGINX_OPENTRACING_VERSION: 0.5.0
-
-image_ubuntu_18_04: &image_ubuntu_18_04
-  docker:
-    - image: datadog/docker-library:dd_opentracing_cpp_ubuntu_18.04_0_2_1
-
-image_ubuntu_16_04: &image_ubuntu_16_04
-  docker:
-    - image: datadog/docker-library:dd_opentracing_cpp_ubuntu_16.04_0_2_1
-
+  CURL_VERSION: 7.60.0
+  NGINX_VERSION: 1.14.0
 
 defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
+  docker:
+    - image: datadog/docker-library:dd_opentracing_cpp_ubuntu_18.04_0_2_1
 
-# Run steps used in more than one job.
-# Unfortunately YAML can't merge lists (only objects), so jobs that share some-but-not-all steps in
-# common must still list all the steps. However the step content itself can be deduplicated.
-_run:
-  # TODO(willgittoes-dd): Cache the results of building source dependencies.
-  build_source_dependencies: &build_source_dependencies
-    name: Build source dependencies
-    command: |
-      # OpenTracing.
-      wget -O opentracing-cpp.tar.gz "https://github.com/opentracing/opentracing-cpp/archive/v${OPENTRACING_VERSION}.tar.gz"
-      mkdir -p "opentracing-cpp/.build"
-      tar zxvf opentracing-cpp.tar.gz -C opentracing-cpp --strip-components=1 
-      pushd "opentracing-cpp/.build"
-      cmake ..
-      make
-      popd
-      # Msgpack
-      wget -O msgpack.tar.gz "https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz"
-      mkdir -p "msgpack/.build"
-      tar zxvf "msgpack.tar.gz" -C msgpack --strip-components=1
-      pushd "msgpack/.build"
-      cmake ..
-      make
-      popd
-  install_source_dependencies: &install_source_dependencies
-    name: Install source dependencies
-    command: |
-      SOURCE_DEPS=("opentracing-cpp" "msgpack")
-      for i in "${SOURCE_DEPS[@]}"
-      do
-        pushd "${i}/.build"
-        make install # Always install to lib, to be used for main build.
-        if [ ! -z "$BUILD_DIR" ]
-        then # Optionally install to build dir if we're going to package it.
-          make install DESTDIR=$BUILD_DIR
-        fi
-        popd
-      done
-  build: &build
-    name: Build
-    command: |
-      rm -rf .build
-      mkdir -p .build
-      cd .build
-      cmake $CMAKE_ARGS ..
-      make
-  install: &install
-    name: Install
-    command: |
-      cd .build
-      make install # Always install to lib, to be used for main build.
-      if [ ! -z "$BUILD_DIR" ]
-      then # Optionally install to build dir if we're going to package it.
-        make install DESTDIR=$BUILD_DIR
-      fi
-  test: &test
-    name: Run Datadog C++ OpenTracing tests
-    command: |
-      cd .build
-      ctest --output-on-failure
-  install_nginx: &install_nginx
-    name: Install nginx
-    command: |
-      CODENAME=$(lsb_release -c | cut -f2) # eg "bionic", "xenial"
-      wget http://nginx.org/keys/nginx_signing.key
-      apt-key add nginx_signing.key
-      echo deb http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list
-      echo deb-src http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list
-      apt-get update
-      # Installs latest stable nginx.
-      apt-get install nginx
-
-# Job templates.
-_jobs:
-  build_base: &build_base
+jobs:
+  build:
     <<: *defaults
     environment:
       <<: *source_dependency_versions
-      CMAKE_ARGS: -DBUILD_TESTING=On
+      CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_SHARED=OFF
+      NGINX_OPENTRACING_VERSION: 0.4.0
     steps:
       - checkout
       - run:
@@ -110,141 +32,45 @@ _jobs:
                 exit 1
               fi
             done
-      - run: *build_source_dependencies
-      - run: *install_source_dependencies
-      - run: *build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./
-      - run: *install
-      - run: *test
-
-  test_sanitizer_base: &test_sanitizer_base
-    <<: *defaults
-    <<: *image_ubuntu_18_04
-    environment:
-      <<: *source_dependency_versions
-    steps:
-      - checkout
-      - run: *build_source_dependencies
-      - run: *install_source_dependencies
-      - run: *build
-      - run: *install
-      - run: *test
-
-  package_base: &package_base
-    <<: *defaults
-    environment:
-      <<: *source_dependency_versions
-      BUILD_DIR: "/tmp/build"
-      ARTIFACT_DIR: "/tmp/artifacts" # Also used in store_artifacts
-    steps:
-      # No checkout step since changing the source file timestamps forces a rebuild. Source is in workspace.
-      - attach_workspace:
-          at: .
-      - run: *install_source_dependencies
-      - run: *install
       - run:
-          name: Build .deb
+          name: Build source dependencies
           command: |
-            # Version number "v1.2.3" -> "1.2.3", otherwise leave unmodified.
-            DD_CPP_VERSION=$(git describe --tags --always  | sed -n -e 's/v\([0-9]*\.[0-9]*\.[0-9]*\)/\1/' -e 'p')
-            CODENAME=$(lsb_release -c | cut -f2) # eg "bionic", "xenial"
-            mkdir -p $ARTIFACT_DIR
-            echo "Building .deb with dd-opentracing-cpp version ${DD_CPP_VERSION}-${CODENAME}"
-            # TODO(willgittoes-dd): Add changelog to package.
-            fpm -s dir -t deb -n datadog-opentracing \
-              -C $BUILD_DIR -p $ARTIFACT_DIR/datadog-opentracing_VERSION_ARCH.deb \
-              -v "${DD_CPP_VERSION}-${CODENAME}" \
-              -m "<will.gittoes@datadoghq.com>" \
-              --deb-priority "optional" \
-              --url "https://github.com/DataDog/dd-opentracing-cpp/tags" \
-              -d libcurl4-openssl-dev \
-              ./
-      - store_artifacts:
-          path: /tmp/artifacts
-
-  package_nginx_module_base: &package_nginx_module_base
-    <<: *defaults
-    environment:
-      <<: *source_dependency_versions
-      BUILD_DIR: "/tmp/build"
-      ARTIFACT_DIR: "/tmp/artifacts" # Also used in persist_to_workspace and store_artifacts
-    steps:
-      # No checkout step since changing the source file timestamps forces a rebuild. Source is in workspace.
-      - attach_workspace:
-          at: .
-      - run: *install_source_dependencies
-      - run: *install
-      - run: *install_nginx
+            ./scripts/install_dependencies.sh
       - run:
-          name: Download and patch nginx module code
+          name: Build
           command: |
-            wget -O nginx-opentracing.tar.gz https://github.com/opentracing-contrib/nginx-opentracing/archive/v${NGINX_OPENTRACING_VERSION}.tar.gz
-            tar zxvf nginx-opentracing.tar.gz
-            pushd nginx-opentracing-${NGINX_OPENTRACING_VERSION}
-            patch -p1 < ../nginx-opentracing-datadog.patch
-            popd
-      - run:
-          name: Build nginx modules
-          command: |
-            NGINX_VERSION=$(nginx -v 2>&1 | sed -nr 's/.*nginx\/([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-            # TODO(willgittoes-dd): Consider using source from source package, rather than re-downloading.
-            wget http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
-            tar zxvf nginx-$NGINX_VERSION.tar.gz
-            pushd nginx-$NGINX_VERSION
-            NGINX_CONFIGURE_ARGS=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/configure arguments: //p')
-            eval "./configure \
-              $NGINX_CONFIGURE_ARGS \
-              --add-dynamic-module=../nginx-opentracing-${NGINX_OPENTRACING_VERSION}/opentracing \
-              --add-dynamic-module=../nginx-opentracing-${NGINX_OPENTRACING_VERSION}/datadog"
-            make modules
-            MODULE_INSTALL_PATH=$(echo $NGINX_CONFIGURE_ARGS | sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p')
-            mkdir -p $BUILD_DIR$MODULE_INSTALL_PATH
-            cp objs/ngx_http_opentracing_module.so $BUILD_DIR$MODULE_INSTALL_PATH
-            cp objs/ngx_http_datadog_module.so $BUILD_DIR$MODULE_INSTALL_PATH
-      - run:
-          name: Build nginx module .deb
-          command: |
-            # Version number "v1.2.3" -> "1.2.3", otherwise ensure numeric prefix.
-            DD_CPP_VERSION=$(git describe --tags --always | sed -n -e 's/v\([0-9]*\.[0-9]*\.[0-9]*\)/\1/' -e 's/\([^0-9].*\)/0-\1/' -e 'p')
-            CODENAME=$(lsb_release -c | cut -f2) # eg "bionic", "xenial"
-            NGINX_VERSION=$(nginx -v 2>&1 | sed -nr 's/.*nginx\/([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
-            mkdir -p $ARTIFACT_DIR
-            echo "Building .deb with dd-opentracing-cpp version ${DD_CPP_VERSION}-${CODENAME} for nginx version ${NGINX_VERSION}"
-            # TODO(willgittoes-dd): Add changelog to package.
-            fpm -s dir -t deb -n datadog-opentracing-nginx \
-              -C $BUILD_DIR -p $ARTIFACT_DIR/datadog-opentracing-nginx_VERSION_ARCH.deb \
-              -v "${DD_CPP_VERSION}-${CODENAME}" \
-              -m "<will.gittoes@datadoghq.com>" \
-              --deb-priority "optional" \
-              --url "https://github.com/DataDog/dd-opentracing-cpp/tags" \
-              -d libcurl4-openssl-dev -d "nginx > ${NGINX_VERSION}" \
-              ./
+            rm -rf .build
+            mkdir -p .build
+            mkdir -p /tmp/build
+            cd .build
+            cmake $CMAKE_ARGS ..
+            make
       - persist_to_workspace:
           root: /tmp/
           paths:
-            - artifacts
+            - build
       - store_artifacts:
-          path: /tmp/artifacts
+          path: /tmp/build
 
-_run_on_release_tag: &run_on_release_tag
-  filters:
-    tags:
-      only: /v[0-9]+\.[0-9]+\.[0-9]+/
-
-jobs:
-  build_ubuntu_18_04: &build_ubuntu_18_04
-    <<: *build_base
-    <<: *image_ubuntu_18_04
-
-  build_ubuntu_16_04: &build_ubuntu_16_04
-    <<: *build_base
-    <<: *image_ubuntu_16_04
-
-  build:
-    <<: *build_ubuntu_18_04
+  test_sanitizer_base: &test_sanitizer_base
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Build source dependencies
+          command: |
+            ./scripts/install_dependencies.sh
+      - run:
+          name: Build and test
+          command: |
+            rm -rf .build
+            mkdir -p .build
+            mkdir -p /tmp/build
+            cd .build
+            cmake $CMAKE_ARGS ..
+            make
+            cd .build
+            ctest --output-on-failure
 
   test_tsan:
     <<: *test_sanitizer_base
@@ -258,123 +84,50 @@ jobs:
       <<: *source_dependency_versions
       CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_ADDRESS=On
 
-  package_ubuntu_18_04:
-    <<: *package_base
-    <<: *image_ubuntu_18_04
-
-  package_ubuntu_16_04:
-    <<: *package_base
-    <<: *image_ubuntu_16_04
-
-  package_nginx_module_ubuntu_18_04:
-    <<: *package_nginx_module_base
-    <<: *image_ubuntu_18_04
-
-  package_nginx_module_ubuntu_16_04:
-    <<: *package_nginx_module_base
-    <<: *image_ubuntu_16_04
-
-  # Builds the shared lib.
-  plugin:
+  integration_test_nginx:
     <<: *defaults
-    <<: *image_ubuntu_18_04
     environment:
-      <<: *source_dependency_versions
-      BUILD_DIR: "/tmp/build"
-      CMAKE_ARGS: -DBUILD_SHARED=OFF -DBUILD_PLUGIN=ON
+      NGINX_OPENTRACING_VERSION: 0.4.0
     steps:
-      # No checkout step since changing the source file timestamps forces a rebuild. Source is in workspace.
+      - checkout
       - attach_workspace:
           at: .
-      - run: *install_source_dependencies
-      - run: *build
-      - run: *install
       - run:
-          name: "Copy plugin to artifact folder"
-          command: |
-            mkdir -p /tmp/artifacts
-            cp /tmp/build/usr/local/lib/libdd_opentracing_plugin.so /tmp/artifacts/libdd_opentracing_plugin.so
-      - store_artifacts:
-          path: /tmp/artifacts
-
-  integration_test_nginx_ubuntu_18_04:
-    <<: *defaults
-    <<: *image_ubuntu_18_04
-    steps:
-      - attach_workspace:
-          at: .
-      - run: *install_nginx
-      - run:
-          name: Install Datadog OpenTracing nginx module
+          name: Install nginx
           command: |
             CODENAME=$(lsb_release -c | cut -f2) # eg "bionic", "xenial"
-            apt install -y ./artifacts/datadog-opentracing-nginx*${CODENAME}*.deb
-            ldconfig
-            NGINX_CONF=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p')
-            # Different nginx configs have different webroots for the sample page. Make sure our
-            # config points to the right one.
-            WEB_ROOT=$(grep -rh '^\s*root' /etc/nginx/ | head -1)
-            cp test/integration/nginx/nginx.conf $NGINX_CONF
-            sed -i "s|$(grep -rh '^\s*root' ${NGINX_CONF} | head -1)|${WEB_ROOT}|g" ${NGINX_CONF}
+            wget http://nginx.org/keys/nginx_signing.key
+            apt-key add nginx_signing.key
+            echo deb http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list
+            echo deb-src http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list
+            apt-get update
+            apt-get install nginx=${NGINX_VERSION}-1~${CODENAME}
       - run:
-          name: Run tests
+          name: Integration test
           command: |
+            # Install the Datadog plugin
+            cp ./build/libdd_opentracing_plugin.so /usr/local/lib/libdd_opentracing_plugin.so
+            # Change the config to use it.
+            NGINX_MODULES=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p')
+            wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v${NGINX_OPENTRACING_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
+            tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C ${NGINX_MODULES}
             cd ./test/integration/nginx/
+            NGINX_CONF=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p')
+            cp nginx.conf $NGINX_CONF
+            cp dd-config.json /etc/dd-config.json
+            mkdir -p /var/www/
+            cp index.html /var/www/
+            # Run the tests.
             ./nginx_integration_test.sh
 
-
-_workflow_filters:
-  _version_tag: &version_tag
-    # Allows semver or "test" tags, with any suffix.
-    # eg v1.2.3 v0.1.1 v1.2.3-ayy-lmao test test-ayy-lmao
-    # "test" is useful if you want to ensure all workflows run without creating a version.
-    only: /(v[0-9]+\.[0-9]+\.[0-9]|test).*+/
-
-  _run_always: &run_always
-    filters:
-      tags:
-        <<: *version_tag
-
-  _run_on_release_tag: &run_on_release_tag
-    filters:
-      tags:
-        <<: *version_tag
-      branches:
-        ignore: /.*/
 
 workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - build_ubuntu_18_04:
-          <<: *run_always
-      - build_ubuntu_16_04:
-          <<: *run_on_release_tag
-      - test_tsan:
-          <<: *run_always
-      - test_asan:
-          <<: *run_always
-      - plugin:
+      - build
+      - test_tsan
+      - test_asan
+      - integration_test_nginx:
           requires:
-            - build_ubuntu_18_04
-          <<: *run_on_release_tag
-      - package_nginx_module_ubuntu_18_04:
-          requires:
-            - build_ubuntu_18_04
-          <<: *run_always
-      - package_nginx_module_ubuntu_16_04:
-          requires:
-            - build_ubuntu_16_04
-          <<: *run_on_release_tag
-      - package_ubuntu_18_04:
-          requires:
-            - build_ubuntu_18_04
-          <<: *run_on_release_tag
-      - package_ubuntu_16_04:
-          requires:
-            - build_ubuntu_16_04
-          <<: *run_always
-      - integration_test_nginx_ubuntu_18_04:
-          requires:
-            - package_nginx_module_ubuntu_18_04
-          <<: *run_always
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ source_dependency_versions: &source_dependency_versions
   MSGPACK_VERSION: 3.0.1
   OPENTRACING_VERSION: 1.5.0
   CURL_VERSION: 7.60.0
-  NGINX_VERSION: 1.14.0
 
 defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
@@ -41,10 +40,11 @@ jobs:
           command: |
             rm -rf .build
             mkdir -p .build
+            mkdir -p /tmp/build/
             cd .build
             cmake $CMAKE_ARGS ..
             make
-            cp libdd_opentracing_plugin.so /tmp/build
+            cp libdd_opentracing_plugin.so /tmp/build/libdd_opentracing_plugin.so
       - persist_to_workspace:
           root: /tmp/
           paths:
@@ -86,6 +86,7 @@ jobs:
     <<: *defaults
     environment:
       NGINX_OPENTRACING_VERSION: 0.4.0
+      NGINX_VERSION: 1.14.0
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 source_dependency_versions: &source_dependency_versions
   MSGPACK_VERSION: 3.0.1
-  OPENTRACING_VERSION: 1.5.0
+  OPENTRACING_VERSION: 1.4.0
   CURL_VERSION: 7.60.0
 
 defaults: &defaults
@@ -16,7 +16,6 @@ jobs:
     environment:
       <<: *source_dependency_versions
       CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_SHARED=OFF
-      NGINX_OPENTRACING_VERSION: 0.4.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Install nginx
           command: |
-            CODENAME=$(lsb_release -c | cut -f2) # eg "bionic", "xenial"
+            CODENAME=$(lsb_release -s -c) # eg "bionic", "xenial"
             wget http://nginx.org/keys/nginx_signing.key
             apt-key add nginx_signing.key
             echo deb http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eo pipefail
+
+# OpenTracing
+wget https://github.com/opentracing/opentracing-cpp/archive/v${OPENTRACING_VERSION}.tar.gz -O opentracing-cpp.tar.gz
+tar zxvf opentracing-cpp.tar.gz
+mkdir opentracing-cpp-${OPENTRACING_VERSION}/.build
+cd opentracing-cpp-${OPENTRACING_VERSION}/.build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_FLAGS="-fPIC" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_MOCKTRACER=OFF \
+      ..
+make
+make install
+cd ../..
+
+# Msgpack
+wget https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz -O msgpack.tar.gz
+tar zxvf msgpack.tar.gz
+mkdir msgpack-${MSGPACK_VERSION}/.build
+cd msgpack-${MSGPACK_VERSION}/.build
+cmake ..
+make
+make install
+cd ../..
+
+# Libcurl
+wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
+tar zxf curl-${CURL_VERSION}.tar.gz
+cd curl-${CURL_VERSION}
+./configure --disable-ftp \
+            --disable-ldap \
+            --disable-dict \
+            --disable-telnet \
+            --disable-tftp \
+            --disable-pop3 \
+            --disable-smtp \
+            --disable-gopher \
+            --without-ssl \
+            --disable-crypto-auth \
+            --without-axtls \
+            --disable-rtsp \
+            --enable-shared=yes \
+            --enable-static=yes \
+            --with-pic
+make && make install
+cd ..

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -8,7 +8,11 @@ RUN apt-get update && \
 
 WORKDIR ~/
 
-COPY ./ ./dd-opentracing-cpp
+COPY ./3rd_party ./dd-opentracing-cpp/3rd_party
+COPY ./include ./dd-opentracing-cpp/include
+COPY ./scripts ./dd-opentracing-cpp/scripts
+COPY ./src ./dd-opentracing-cpp/src
+COPY ./CMakeLists.txt ./dd-opentracing-cpp/CMakeLists.txt
 RUN export OPENTRACING_VERSION=1.4.0 && \
   export MSGPACK_VERSION=3.0.1 && \
   export CURL_VERSION=7.60.0 && \

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -1,78 +1,58 @@
-FROM ubuntu
+FROM ubuntu:18.04 as build
 
 # Creates an image with nginx and the Datadog OpenTracing nginx module installed.
 # Runs a simple integration test.
 
-ARG OPENTRACING_VERSION=1.4.2
-ARG MSGPACK_VERSION=3.0.1
-ARG NGINX_OPENTRACING_VERSION=0.4.0
-ARG NGINX_VERSION=1.15.0
-
 RUN apt-get update && \
-  apt-get install -y git build-essential libpcre3-dev zlib1g-dev libcurl4-openssl-dev wget curl tar cmake openjdk-8-jre golang jq
+  apt-get install -y git build-essential libpcre3-dev zlib1g-dev libcurl4-openssl-dev wget curl tar cmake
 
 WORKDIR ~/
 
-# Install opentracing dependency
-ADD https://github.com/opentracing/opentracing-cpp/archive/v${OPENTRACING_VERSION}.tar.gz opentracing-cpp.tar.gz
-RUN tar zxvf opentracing-cpp.tar.gz
-RUN mkdir opentracing-cpp-${OPENTRACING_VERSION}/.build
-WORKDIR opentracing-cpp-${OPENTRACING_VERSION}/.build
-RUN cmake ..
-RUN make
-RUN make install
-WORKDIR ../..
-
-# Install msgpack dependency
-ADD https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz msgpack.tar.gz
-RUN tar zxvf msgpack.tar.gz
-RUN mkdir msgpack-${MSGPACK_VERSION}/.build
-WORKDIR msgpack-${MSGPACK_VERSION}/.build
-RUN cmake ..
-RUN make
-RUN make install
-WORKDIR ../..
-
-# Compile dd-opentracing-cpp
-COPY ./src ./dd-opentracing-cpp/src
-COPY ./3rd_party ./dd-opentracing-cpp/3rd_party
-COPY ./include ./dd-opentracing-cpp/include
-COPY ./CMakeLists.txt ./dd-opentracing-cpp/
-RUN find ./ -type f -print0 | xargs -0 md5sum # WHY CACHE BUSTING?
-RUN rm -rf dd-opentracing-cpp/.build 
-RUN mkdir dd-opentracing-cpp/.build
+COPY ./ ./dd-opentracing-cpp
+RUN export OPENTRACING_VERSION=1.4.0 && \
+  export MSGPACK_VERSION=3.0.1 && \
+  export CURL_VERSION=7.60.0 && \
+  cd dd-opentracing-cpp && \
+  ./scripts/install_dependencies.sh
+RUN rm -rf dd-opentracing-cpp/.build
+RUN mkdir -p dd-opentracing-cpp/.build
 WORKDIR dd-opentracing-cpp/.build
-RUN cmake -DBUILD_TESTING=OFF ..
+RUN cmake -DBUILD_PLUGIN=ON -DBUILD_TESTING=OFF -DBUILD_SHARED=OFF ..
 RUN make
 RUN make install
-WORKDIR ../..
 
-# Fetch and patch the nginx-opentracing module
-ADD https://github.com/opentracing-contrib/nginx-opentracing/archive/v${NGINX_OPENTRACING_VERSION}.tar.gz nginx-opentracing.tar.gz
-COPY ./nginx-opentracing-datadog.patch ./dd-opentracing-cpp/
-RUN tar zxvf nginx-opentracing.tar.gz
-WORKDIR nginx-opentracing-${NGINX_OPENTRACING_VERSION}
-RUN patch -p1 < ../dd-opentracing-cpp/nginx-opentracing-datadog.patch
-WORKDIR ..
+
+FROM ubuntu:18.04
+
+ARG NGINX_VERSION=1.14.0
+ARG NGINX_OPENTRACING_VERSION=0.4.0
+
+RUN apt-get update && \
+  apt-get install -y git gnupg lsb-release wget curl tar cmake openjdk-8-jre golang jq
 
 # Install nginx
-# Note: Installs nginx from source. In production environments you would want to install nginx from
-# the official repos, and use the packaged binary of the OpenTracing module. The CI version of this
-# integration test does exactly that. Here we just build from source since it's a bit more terse.
-ADD http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz nginx-${NGINX_VERSION}.tar.gz
-RUN tar zxvf nginx-${NGINX_VERSION}.tar.gz
-WORKDIR nginx-${NGINX_VERSION}
-RUN ./configure \
-  --add-dynamic-module=../nginx-opentracing-${NGINX_OPENTRACING_VERSION}/opentracing \
-  --add-dynamic-module=../nginx-opentracing-${NGINX_OPENTRACING_VERSION}/datadog
-RUN make
-RUN make install
-WORKDIR ../
+RUN CODENAME=$(lsb_release -c | cut -f2) && \
+  wget http://nginx.org/keys/nginx_signing.key && \
+  apt-key add nginx_signing.key && \
+  echo deb http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list && \
+  echo deb-src http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get install nginx=${NGINX_VERSION}-1~${CODENAME}
 
-RUN ldconfig
+# Install OpenTracing
+ADD https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.4.0/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
+RUN NGINX_MODULES=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p') && \
+  tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C ${NGINX_MODULES}
+# And Datadog OT
+COPY --from=build /usr/local/lib/libdd_opentracing_plugin.so /usr/local/lib/libdd_opentracing_plugin.so
 
 # Add OpenTracing directives to nginx config
-COPY ./test/integration/nginx/nginx.conf /usr/local/nginx/conf/nginx.conf
+COPY ./test/integration/nginx/nginx.conf /tmp/nginx.conf
+RUN NGINX_CONF=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p') && \
+  mv /tmp/nginx.conf ${NGINX_CONF}
+COPY ./test/integration/nginx/dd-config.json /etc/dd-config.json
+RUN mkdir -p /var/www/
+COPY ./test/integration/nginx/index.html /var/www/index.html
 
 # Get Wiremock
 ADD http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.18.0/wiremock-standalone-2.18.0.jar wiremock-standalone-2.18.0.jar

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
   apt-get install -y git gnupg lsb-release wget curl tar cmake openjdk-8-jre golang jq
 
 # Install nginx
-RUN CODENAME=$(lsb_release -c | cut -f2) && \
+RUN CODENAME=$(lsb_release -s -c) && \
   wget http://nginx.org/keys/nginx_signing.key && \
   apt-key add nginx_signing.key && \
   echo deb http://nginx.org/packages/ubuntu/ ${CODENAME} nginx >> /etc/apt/sources.list && \

--- a/test/integration/nginx/dd-config.json
+++ b/test/integration/nginx/dd-config.json
@@ -1,0 +1,5 @@
+{
+  "service": "nginx",
+  "agent_host": "localhost",
+  "agent_port": 8126
+}

--- a/test/integration/nginx/expected.json
+++ b/test/integration/nginx/expected.json
@@ -1,217 +1,139 @@
 [
   [
     {
-      "duration": 100600,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "http_user_agent": "curl/7.58.0",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59788"
+        "http.url": "http://localhost/"
       },
       "name": "/",
-      "parent_id": 3077890638333398801,
       "resource": "/",
-      "service": "",
-      "span_id": 1038003031200511244,
-      "start": 1529366415347993400,
-      "trace_id": 3077890638333398801,
+      "service": "nginx",
       "type": "web"
     },
     {
-      "duration": 201300,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "http_user_agent": "curl/7.58.0",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59788"
+        "http.url": "http://localhost/"
       },
       "name": "/",
-      "parent_id": 3077890638333398801,
       "resource": "/",
-      "service": "",
-      "span_id": 558024124467689323,
-      "start": 1529366415348126300,
-      "trace_id": 3077890638333398801,
+      "service": "nginx",
       "type": "web"
     },
     {
-      "duration": 443100,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59788"
+        "http.url": "http://localhost/"
       },
-      "name": "nginx /index.html",
-      "parent_id": 0,
-      "resource": "nginx /index.html",
-      "service": "",
-      "span_id": 3077890638333398801,
-      "start": 1529366415347934600,
-      "trace_id": 3077890638333398801,
+      "name": "/index.html",
+      "resource": "/index.html",
+      "service": "nginx",
       "type": "web"
     }
   ],
   [
     {
-      "duration": 56600,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "http_user_agent": "curl/7.58.0",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59790"
+        "http.url": "http://localhost/"
       },
       "name": "/",
-      "parent_id": 2273817048390843606,
       "resource": "/",
-      "service": "",
-      "span_id": 4586175885466938091,
-      "start": 1529366415361258900,
-      "trace_id": 2273817048390843606,
+      "service": "nginx",
       "type": "web"
     },
     {
-      "duration": 109100,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "http_user_agent": "curl/7.58.0",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59790"
+        "http.url": "http://localhost/"
       },
       "name": "/",
-      "parent_id": 2273817048390843606,
       "resource": "/",
-      "service": "",
-      "span_id": 15925010764088517852,
-      "start": 1529366415361338400,
-      "trace_id": 2273817048390843606,
+      "service": "nginx",
       "type": "web"
     },
     {
-      "duration": 269600,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59790"
+        "http.url": "http://localhost/"
       },
-      "name": "nginx /index.html",
-      "parent_id": 0,
-      "resource": "nginx /index.html",
-      "service": "",
-      "span_id": 2273817048390843606,
-      "start": 1529366415361216900,
-      "trace_id": 2273817048390843606,
+      "name": "/index.html",
+      "resource": "/index.html",
+      "service": "nginx",
       "type": "web"
     }
   ],
   [
     {
-      "duration": 74300,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "http_user_agent": "curl/7.58.0",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59792"
+        "http.url": "http://localhost/"
       },
       "name": "/",
-      "parent_id": 16270541406347938660,
       "resource": "/",
-      "service": "",
-      "span_id": 1906642885562923028,
-      "start": 1529366415374230300,
-      "trace_id": 16270541406347938660,
+      "service": "nginx",
       "type": "web"
     },
     {
-      "duration": 138700,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "http_user_agent": "curl/7.58.0",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59792"
+        "http.url": "http://localhost/"
       },
       "name": "/",
-      "parent_id": 16270541406347938660,
       "resource": "/",
-      "service": "",
-      "span_id": 8844214294041295617,
-      "start": 1529366415374335800,
-      "trace_id": 16270541406347938660,
+      "service": "nginx",
       "type": "web"
     },
     {
-      "duration": 365200,
       "error": 0,
       "meta": {
         "_sample_rate": "1.000000",
         "component": "nginx",
-        "http.host": "localhost",
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
-        "http.url": "http://localhost/",
-        "nginx.worker_pid": "315",
-        "peer.address": "127.0.0.1:59792"
+        "http.url": "http://localhost/"
       },
-      "name": "nginx /index.html",
-      "parent_id": 0,
-      "resource": "nginx /index.html",
-      "service": "",
-      "span_id": 16270541406347938660,
-      "start": 1529366415374176000,
-      "trace_id": 16270541406347938660,
+      "name": "/index.html",
+      "resource": "/index.html",
+      "service": "nginx",
       "type": "web"
     }
   ]

--- a/test/integration/nginx/index.html
+++ b/test/integration/nginx/index.html
@@ -1,0 +1,1 @@
+Hello world

--- a/test/integration/nginx/nginx.conf
+++ b/test/integration/nginx/nginx.conf
@@ -1,5 +1,4 @@
 load_module modules/ngx_http_opentracing_module.so;
-load_module modules/ngx_http_datadog_module.so;
 
 events {
     worker_connections  1024;
@@ -8,17 +7,16 @@ events {
 http {
     opentracing on;
     opentracing_tag http_user_agent $http_user_agent;
-    datadog_agent_host localhost;
-    datadog_agent_port 8129;
-    datadog_write_period_ms 10000;
+    
+    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/dd-config.json;
 
     server {
         listen       80;
         server_name  localhost;
 
         location / {
-            opentracing_operation_name "nginx $uri";
-            root   html;
+            opentracing_operation_name "$uri";
+            root   /var/www;
         }
     }
 }

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -56,7 +56,7 @@ touch ~/got.json
 while ((I++ < 15)) && [[ $(jq 'length' ~/got.json) != "3" ]]
 do
   sleep 1
-  rm -rf ~/requests.json
+  echo "" > ~/requests.json
   REQUESTS=$(curl -s http://localhost:8126/__admin/requests)
   echo "${REQUESTS}" | jq -r '.requests[].request.bodyAsBase64' | while read line; 
   do 


### PR DESCRIPTION
Building a shared plugin means no more distributing by deb package, since the plugin is more portable. This means we can simplify CI.

This also makes the integration test use the plugin, and makes it not flake in the case when more-than-1 agent requests are sent.