### PR TITLE
Improve URLs and Span Naming

### DIFF
--- a/test/integration/nginx/expected.json
+++ b/test/integration/nginx/expected.json
@@ -6,41 +6,12 @@
         "_sample_rate": "1.000000",
         "component": "nginx",
         "http.method": "GET",
-        "http.status_line": "",
-        "http.url": "http://localhost/"
-      },
-      "name": "/",
-      "resource": "/",
-      "service": "nginx",
-      "type": "web"
-    },
-    {
-      "error": 0,
-      "meta": {
-        "_sample_rate": "1.000000",
-        "component": "nginx",
-        "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
         "http.url": "http://localhost/"
       },
-      "name": "/",
-      "resource": "/",
-      "service": "nginx",
-      "type": "web"
-    },
-    {
-      "error": 0,
-      "meta": {
-        "_sample_rate": "1.000000",
-        "component": "nginx",
-        "http.method": "GET",
-        "http.status_code": "200",
-        "http.status_line": "",
-        "http.url": "http://localhost/"
-      },
-      "name": "/index.html",
-      "resource": "/index.html",
+      "name": "GET /index.html",
+      "resource": "GET /index.html",
       "service": "nginx",
       "type": "web"
     }
@@ -52,41 +23,12 @@
         "_sample_rate": "1.000000",
         "component": "nginx",
         "http.method": "GET",
-        "http.status_line": "",
-        "http.url": "http://localhost/"
-      },
-      "name": "/",
-      "resource": "/",
-      "service": "nginx",
-      "type": "web"
-    },
-    {
-      "error": 0,
-      "meta": {
-        "_sample_rate": "1.000000",
-        "component": "nginx",
-        "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
         "http.url": "http://localhost/"
       },
-      "name": "/",
-      "resource": "/",
-      "service": "nginx",
-      "type": "web"
-    },
-    {
-      "error": 0,
-      "meta": {
-        "_sample_rate": "1.000000",
-        "component": "nginx",
-        "http.method": "GET",
-        "http.status_code": "200",
-        "http.status_line": "",
-        "http.url": "http://localhost/"
-      },
-      "name": "/index.html",
-      "resource": "/index.html",
+      "name": "GET /index.html",
+      "resource": "GET /index.html",
       "service": "nginx",
       "type": "web"
     }
@@ -98,41 +40,12 @@
         "_sample_rate": "1.000000",
         "component": "nginx",
         "http.method": "GET",
-        "http.status_line": "",
-        "http.url": "http://localhost/"
-      },
-      "name": "/",
-      "resource": "/",
-      "service": "nginx",
-      "type": "web"
-    },
-    {
-      "error": 0,
-      "meta": {
-        "_sample_rate": "1.000000",
-        "component": "nginx",
-        "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "",
         "http.url": "http://localhost/"
       },
-      "name": "/",
-      "resource": "/",
-      "service": "nginx",
-      "type": "web"
-    },
-    {
-      "error": 0,
-      "meta": {
-        "_sample_rate": "1.000000",
-        "component": "nginx",
-        "http.method": "GET",
-        "http.status_code": "200",
-        "http.status_line": "",
-        "http.url": "http://localhost/"
-      },
-      "name": "/index.html",
-      "resource": "/index.html",
+      "name": "GET /index.html",
+      "resource": "GET /index.html",
       "service": "nginx",
       "type": "web"
     }

--- a/test/integration/nginx/nginx.conf
+++ b/test/integration/nginx/nginx.conf
@@ -7,6 +7,7 @@ events {
 http {
     opentracing on;
     opentracing_tag http_user_agent $http_user_agent;
+    opentracing_trace_locations off;
     
     opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/dd-config.json;
 
@@ -15,7 +16,7 @@ http {
         server_name  localhost;
 
         location / {
-            opentracing_operation_name "$uri";
+            opentracing_operation_name "$request_method $uri";
             root   /var/www;
         }
     }

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -56,7 +56,7 @@ touch ~/got.json
 while ((I++ < 15)) && [[ $(jq 'length' ~/got.json) != "3" ]]
 do
   sleep 1
-  rm -rf ~/requests.json
+  echo "" > ~/requests.json
   REQUESTS=$(curl -s http://localhost:8126/__admin/requests)
   echo "${REQUESTS}" | jq -r '.requests[].request.bodyAsBase64' | while read line; 
   do 


### PR DESCRIPTION
This activates (in the integration test) the opentracing-nginx option to only create one span per request, which allows us to specify the span_name in the nginx config file.

It also adds a very basic (and cargo-culted from the Java tracer) regex that strips data from any tag named http.url, to help with PII and cardinality. 