### PR TITLE
Set resource name independently of operation name in nginx tracing

### DIFF
--- a/test/integration/nginx/expected.json
+++ b/test/integration/nginx/expected.json
@@ -12,7 +12,7 @@
         "operation": "GET /index.html"
       },
       "name": "nginx.handle",
-      "resource": "nginx.handle",
+      "resource": "/",
       "service": "nginx",
       "type": "web"
     }
@@ -30,7 +30,7 @@
         "operation": "GET /index.html"
       },
       "name": "nginx.handle",
-      "resource": "nginx.handle",
+      "resource": "/",
       "service": "nginx",
       "type": "web"
     }
@@ -48,7 +48,7 @@
         "operation": "GET /index.html"
       },
       "name": "nginx.handle",
-      "resource": "nginx.handle",
+      "resource": "/",
       "service": "nginx",
       "type": "web"
     }

--- a/test/integration/nginx/nginx.conf
+++ b/test/integration/nginx/nginx.conf
@@ -17,6 +17,7 @@ http {
 
         location / {
             opentracing_operation_name "$request_method $uri";
+            opentracing_tag "resource.name" "/";
             root   /var/www;
         }
     }

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -262,6 +262,35 @@ TEST_CASE("span") {
               "original resource",
               "overridden operation name"};
 
+    span.SetTag("resource.name", "new resource");
+    const ot::FinishSpanOptions finish_options;
+    span.FinishWithOptions(finish_options);
+
+    auto& result = buffer->traces[100].finished_spans->at(0);
+    REQUIRE(result->meta ==
+            std::unordered_map<std::string, std::string>{{"operation", "original span name"}});
+    REQUIRE(result->name == "overridden operation name");
+    REQUIRE(result->resource == "new resource");
+    REQUIRE(result->service == "original service");
+    REQUIRE(result->type == "original type");
+  }
+
+  SECTION("special resource tag has priority over operation name override") {
+    auto span_id = get_id();
+    Span span{nullptr,
+              std::shared_ptr<SpanBuffer>{buffer},
+              get_time,
+              span_id,
+              span_id,
+              0,
+              std::move(SpanContext{span_id, span_id, {}}),
+              get_time(),
+              "original service",
+              "original type",
+              "original span name",
+              "original resource",
+              "overridden operation name"};
+
     const ot::FinishSpanOptions finish_options;
     span.FinishWithOptions(finish_options);
 

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -262,7 +262,6 @@ TEST_CASE("span") {
               "original resource",
               "overridden operation name"};
 
-    span.SetTag("resource.name", "new resource");
     const ot::FinishSpanOptions finish_options;
     span.FinishWithOptions(finish_options);
 
@@ -270,7 +269,7 @@ TEST_CASE("span") {
     REQUIRE(result->meta ==
             std::unordered_map<std::string, std::string>{{"operation", "original span name"}});
     REQUIRE(result->name == "overridden operation name");
-    REQUIRE(result->resource == "new resource");
+    REQUIRE(result->resource == "overridden operation name");
     REQUIRE(result->service == "original service");
     REQUIRE(result->type == "original type");
   }
@@ -291,6 +290,7 @@ TEST_CASE("span") {
               "original resource",
               "overridden operation name"};
 
+    span.SetTag("resource.name", "new resource");
     const ot::FinishSpanOptions finish_options;
     span.FinishWithOptions(finish_options);
 
@@ -298,7 +298,7 @@ TEST_CASE("span") {
     REQUIRE(result->meta ==
             std::unordered_map<std::string, std::string>{{"operation", "original span name"}});
     REQUIRE(result->name == "overridden operation name");
-    REQUIRE(result->resource == "overridden operation name");
+    REQUIRE(result->resource == "new resource");
     REQUIRE(result->service == "original service");
     REQUIRE(result->type == "original type");
   }


### PR DESCRIPTION
Allow resource-name-from-tag to take priority over operation-name-override. This allows us to have sanitised span names using operation_name_override, but still allow users to set their own resource names.