### PR TITLE
Update nginx example and documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
     docker:
       - image: datadog/docker-library:dd_opentracing_cpp_test_0_3_0
     environment:
-      NGINX_OPENTRACING_VERSION: 0.4.0
+      NGINX_OPENTRACING_VERSION: 0.6.0
       NGINX_VERSION: 1.14.0
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@
 **Notice: This project is still in beta, under active development. Features and compatibility may change.**
 
 * [Usage](#usage)
-   * [Tracing nginx](#nginx)
-      * [Quick start/Example](#example)
+   * [Tracing nginx](#tracing-nginx)
+      * [Quick start/Example](#quick-start-with-docker-example)
       * [Guide](#guide)
 * [Development](#building)
-
-<a name="usage"/>
 
 ## Usage
 
@@ -18,13 +16,9 @@
 
 Support coming soon.
 
-<a name="nginx"/>
-
 ### Tracing Nginx
 
 Nginx can be traced using the nginx-opentracing module along with this library.
-
-<a name="example"/>
 
 #### Quick-start with Docker example
 
@@ -33,8 +27,6 @@ Nginx can be traced using the nginx-opentracing module along with this library.
 3. `docker-compose up --build`
 4. Visit http://localhost:8080
 5. Observe traces in Datadog APM under service name "nginx".
-
-<a name="guide"/>
 
 #### Guide
 
@@ -126,8 +118,6 @@ You also need to provide a JSON-formatted text config file that sets options for
 ### Tracing Envoy & Istio
 
 Coming soon!
-
-<a name="building"/>
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,115 @@
 
 **Notice: This project is still in beta, under active development. Features and compatibility may change.**
 
+## Usage
+
+### Tracing C++ Code
+
+Support coming soon.
+
+### Tracing Nginx
+
+Nginx can be traced using the nginx-opentracing module along with this library.
+
+#### Quick-start with Docker example
+
+1. Put your Datadog API key in examples/nginx-tracing/docker-compose.yml
+2. `cd examples/nginx-tracing`
+3. `docker-compose up --build`
+4. Visit http://localhost:8080
+5. Observe traces in Datadog APM under service name "nginx".
+
+#### Explanation
+
+Explains how the Docker example works.
+
+Nginx tracing is compatible with the nginx binary package from the official nginx [repositories](http://nginx.org/en/linux_packages.html#stable). eg.
+
+```bash
+wget https://nginx.org/keys/nginx_signing.key
+apt-key add nginx_signing.key
+echo deb https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list
+echo deb-src https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list
+apt-get update
+apt-get install nginx=1.14.0-1~bionic # <- Your Ubuntu distro here
+```
+
+Two dynamic libraries need to be available:
+
+* ngx_http_opentracing_module.so, provided by [nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing/)
+* libdd_opentracing_plugin.so, from this repo
+
+Each of these can be downloaded and used precompiled.
+
+```bash
+# Install OpenTracing nginx module
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.6.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz
+tar zxf linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+# Install Datadog OpenTracing
+wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/v0.2.0/libdd_opentracing_plugin.so.gz
+gunzip libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
+```
+
+Tracing is configured in two locations:
+
+* Your nginx config.
+* A datadog-specific JSON-formatted config file. This can be placed anywhere readable by nginx, and is referenced in the nginx config file.
+
+Annotated nginx config file:
+
+```nginx
+load_module modules/ngx_http_opentracing_module.so; # Load OpenTracing module
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    opentracing on; # Enable OpenTracing
+    opentracing_tag http_user_agent $http_user_agent; # Add a tag to each trace!
+    opentracing_trace_locations off; # Emit only one span per request.
+
+    # Load the Datadog tracing implementation, and the given config file.
+    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/dd-config.json;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        location /test {
+            # Enable tracing for this location block and set the operation name.
+            opentracing_operation_name "$request_method $uri";
+            # Set the resource for the span.
+            opentracing_tag "resource.name" "/test";
+            root   /var/www;
+        }
+    }
+}
+```
+
+Annotated Datadog config JSON:
+
+```javascript
+// Note, not valid JSON. JSON may not have comments!
+{
+  // The only required field. Sets the service name.
+  "service": "nginx",
+  // Not required but highly reccommended option. Normalises span names so that all nginx traces can be found easily in the Datadog UI, replacing the OpenTracing operation name with the value provided here (keeping the operation name as a tag). The opentracing_tag nginx directive can still be used to set the "resource.name" tag to set resource names.
+  "operation_name_override": "nginx.handle",
+  // These define the address of the trace agent. The default values are below.
+  "agent_host": "localhost",
+  "agent_port": 8126,
+  // Client-side sampling. Discards (without counting) some number of traces where 1.0 means "keep all traces" and 0.0 means "keep no traces". Useful for improving performance in the case where nginx receives a large number of very small requests. Default value is 1.0 / keep everything.
+  "sample_rate": 1.0
+}
+```
+
+You also need to provide a JSON-formatted text config file that sets options for the Datadog tracing.
+
+### Tracing Envoy & Istio
+
+Coming soon!
+
 ## Building
 
 **Dependencies**
@@ -13,6 +122,8 @@
 - [msgpack-c](ttps://github.com/msgpack/msgpack-c/)
 - [libCURL](https://curl.haxx.se/libcurl/)
 - Build tools (eg. build-essential, xcode)
+
+See scripts/install_dependencies.sh
 
 **Build steps**
 
@@ -24,116 +135,16 @@
 
 **Running the tests**
 
-Either just run `circleci build` or:
-
     mkdir .build
     cd .build
-    cmake ..
+    cmake -DBUILD_TESTING=ON ..
     make
     ctest --output-on-failure
 
 `make test` also works instead of calling ctest, but [doesn't print](https://stackoverflow.com/questions/5709914/using-cmake-how-do-i-get-verbose-output-from-ctest) which tests are failing.
 
-If you want [sanitizers](https://github.com/google/sanitizers) to be enabled, then instead of `cmake ..`, use either `cmake -DSANITIZE_THREAD=On -DSANITIZE_UNDEFINED=On ..` or `cmake -DSANITIZE_ADDRESS=On ..`, running the tests will now also check with the sanitizers.
+If you want [sanitizers](https://github.com/google/sanitizers) to be enabled, then add either the `-DSANITIZE_THREAD=ON -DSANITIZE_UNDEFINED=ON` or `-DSANITIZE_ADDRESS=ON` flags to cmake, running the tests will now also check with the sanitizers.
 
 **Running integration/e2e tests**
 
-    cd test/integration
-    ./run_integration_tests_local.sh
-
-## Usage
-
-### Tracing C++ Code
-
-Support coming soon.
-
-### Tracing Nginx
-
-Currently nginx needs compilation against any modules used, although there may be future support for hot-loading dynamically-linked modules.
-
-#### Quick-start with Docker
-
-1. Get a Datadog agent up and running
-2. Modify examples/nginx-tracing/nginx.conf to set the `datadog_agent_host` and `datadog_agent_port`
-3. `cd examples/nginx`
-4. `docker-compose up --build`
-5. Visit http://localhost:8080
-
-#### Build it yourself
-
-First, [build and install](#building) the Datadog OpenTracing C++ client.
-
-    git clone git@github.com:DataDog/dd-opentracing-cpp.git
-    # and then build as above
-
-Download the [nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing/releases) module code
-
-    wget https://github.com/opentracing-contrib/nginx-opentracing/archive/v0.2.1.tar.gz
-    tar zxvf nginx-opentracing-0.2.1.tar.gz
-
-*Note: The next step only required until the Datadog opentracing-nginx patch is merged*
-
-Patch nginx-opentracing to add Datadog support
-
-     cd nginx-opentracing-0.2.1
-     patch -p1 < ../dd-opentracing-cpp/nginx-opentracing-datadog.patch
-     cd ../
-
-Install nginx dependencies, eg
-
-    apt-get update
-    apt-get install -y git build-essential libpcre3-dev zlib1g-dev libcurl4-openssl-dev wget curl tar cmake
-
-Download nginx source
-
-    wget http://nginx.org/download/nginx-1.13.10.tar.gz
-    tar zxvf nginx-1.13.10.tar.gz
-
-Build and install nginx
-
-    cd nginx-1.13.10
-    ./configure \
-        --add-dynamic-module=../nginx-opentracing-0.2.1/opentracing \
-        --add-dynamic-module=../nginx-opentracing-0.2.1/datadog
-    make
-    make install
-    cd ..
-
-Create an nginx config that loads and uses the module.
-
-    cat <<EOT >> nginx.conf
-    load_module modules/ngx_http_opentracing_module.so;
-    load_module modules/ngx_http_datadog_module.so;
-
-    events {
-        worker_connections  1024;
-    }
-
-    http {
-        opentracing on;
-        opentracing_tag http_user_agent $http_user_agent;
-        datadog_agent_host localhost; # IP address or hostname of agent
-        datadog_agent_port 8129;
-
-        server {
-            listen       80;
-            server_name  localhost;
-
-            location / {
-                opentracing_operation_name $uri;
-                root   html;
-                index  index.html index.htm;
-            }
-
-            location /test {
-                opentracing_operation_name $uri;
-                root   html;
-                index  index.html index.htm;
-            }
-        }
-    }
-    EOT
-
-Run nginx with that configuration
-
-    nginx -c nginx.conf
+    ./test/integration/run_integration_tests_local.sh

--- a/README.md
+++ b/README.md
@@ -4,15 +4,27 @@
 
 **Notice: This project is still in beta, under active development. Features and compatibility may change.**
 
+* [Usage](#usage)
+   * [Tracing nginx](#nginx)
+      * [Quick start/Example](#example)
+      * [Guide](#guide)
+* [Development](#building)
+
+<a name="usage"/>
+
 ## Usage
 
 ### Tracing C++ Code
 
 Support coming soon.
 
+<a name="nginx"/>
+
 ### Tracing Nginx
 
 Nginx can be traced using the nginx-opentracing module along with this library.
+
+<a name="example"/>
 
 #### Quick-start with Docker example
 
@@ -22,7 +34,9 @@ Nginx can be traced using the nginx-opentracing module along with this library.
 4. Visit http://localhost:8080
 5. Observe traces in Datadog APM under service name "nginx".
 
-#### Explanation
+<a name="guide"/>
+
+#### Guide
 
 Explains how the Docker example works.
 
@@ -112,6 +126,8 @@ You also need to provide a JSON-formatted text config file that sets options for
 ### Tracing Envoy & Istio
 
 Coming soon!
+
+<a name="building"/>
 
 ## Building
 

--- a/examples/nginx-tracing/Dockerfile
+++ b/examples/nginx-tracing/Dockerfile
@@ -1,64 +1,35 @@
 # Builds and runs a simple nginx server, traced by Datadog
-FROM ubuntu
+FROM ubuntu:18.04
 
-RUN apt-get update
-RUN apt-get install -y git build-essential libpcre3-dev zlib1g-dev libcurl4-openssl-dev wget curl tar cmake
+ARG NGINX_VERSION=1.14.0
+ARG NGINX_OPENTRACING_VERSION=0.6.0
+ARG DATADOG_PLUGIN_VERSION=0.2.1
 
-# Install opentracing dependency
-RUN wget -O opentracing-cpp.tar.gz https://github.com/opentracing/opentracing-cpp/archive/v1.3.0.tar.gz
-RUN tar zxvf opentracing-cpp.tar.gz
-RUN mkdir opentracing-cpp-1.3.0/.build
-WORKDIR opentracing-cpp-1.3.0/.build
-RUN cmake ..
-RUN make
-RUN make install
-WORKDIR ../..
+RUN apt-get update && \
+    apt-get install -y git gnupg wget tar
 
-# Install msgpack dependency
-RUN wget https://github.com/msgpack/msgpack-c/releases/download/cpp-2.1.5/msgpack-2.1.5.tar.gz
-RUN tar zxvf msgpack-2.1.5.tar.gz
-RUN mkdir msgpack-2.1.5/.build
-WORKDIR msgpack-2.1.5/.build
-RUN cmake ..
-RUN make
-RUN make install
-WORKDIR ../..
+# Install nginx
+RUN wget https://nginx.org/keys/nginx_signing.key && \
+    apt-key add nginx_signing.key && \
+    echo deb https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
+    echo deb-src https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install nginx=${NGINX_VERSION}-1~bionic
+# Configure nginx.
+COPY ./examples/nginx-tracing/nginx.conf /etc/nginx/nginx.conf
+COPY ./examples/nginx-tracing/dd-config.json /etc/dd-config.json
+RUN mkdir -p /var/www/
+COPY ./examples/nginx-tracing/index.html /var/www/index.html
 
-# Compile dd-opentracing-cpp
-ADD ./ ./dd-opentracing-cpp/
-RUN rm -rf dd-opentracing-cpp/.build 
-RUN mkdir dd-opentracing-cpp/.build
-WORKDIR dd-opentracing-cpp/.build
-RUN cmake -DBUILD_TESTING=ON ..
-RUN make
-RUN make install
-# Warning: Sanitizers (tsan, usan, asan) are not run on these tests, see the CircleCI
-# config.yml for an example of running tests with those checks.
-RUN ctest --output-on-failure
-WORKDIR ../..
+# Install OpenTracing
+ADD https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v${NGINX_OPENTRACING_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
+RUN tar zxf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
+# And Datadog OT
+ADD https://github.com/DataDog/dd-opentracing-cpp/releases/download/v${DATADOG_PLUGIN_VERSION}/libdd_opentracing_plugin.so.gz libdd_opentracing_plugin.so.gz
+RUN gunzip libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
 
-# Fetch and patch the nginx-opentracing module
-RUN wget -O nginx-opentracing.tar.gz https://github.com/opentracing-contrib/nginx-opentracing/archive/v0.2.1.tar.gz
-RUN tar zxvf nginx-opentracing.tar.gz
-WORKDIR nginx-opentracing-0.2.1
-RUN patch -p1 < ../dd-opentracing-cpp/nginx-opentracing-datadog.patch
-WORKDIR ..
-
-# Build nginx
-RUN wget http://nginx.org/download/nginx-1.13.10.tar.gz
-RUN tar zxvf nginx-1.13.10.tar.gz
-WORKDIR nginx-1.13.10
-RUN ./configure \
-    --add-dynamic-module=../nginx-opentracing-0.2.1/opentracing \
-    --add-dynamic-module=../nginx-opentracing-0.2.1/datadog
-RUN make
-RUN make install
-WORKDIR ..
-
-RUN ldconfig
-
-ADD ./examples/nginx-tracing/nginx.conf /usr/local/nginx/conf/nginx.conf
-RUN /usr/local/nginx/sbin/nginx -t
+# Test nginx config.
+RUN nginx -t
 
 EXPOSE 80
-CMD [ "/usr/local/nginx/sbin/nginx", "-g", "daemon off;"]
+CMD [ "nginx", "-g", "daemon off;"]

--- a/examples/nginx-tracing/nginx.conf
+++ b/examples/nginx-tracing/nginx.conf
@@ -1,5 +1,4 @@
 load_module modules/ngx_http_opentracing_module.so;
-load_module modules/ngx_http_datadog_module.so;
 
 events {
     worker_connections  1024;
@@ -8,25 +7,24 @@ events {
 http {
     opentracing on;
     opentracing_tag http_user_agent $http_user_agent;
-    datadog_agent_host dd-agent; # IP address or hostname of agent
-    datadog_agent_port 8126;
-    datadog_service_name nginx;
-    datadog_sample_rate 1.0;
+    opentracing_trace_locations off;
+
+    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/dd-config.json;
 
     server {
         listen       80;
         server_name  localhost;
 
         location / {
-            opentracing_operation_name "nginx ${uri}";
-            root   html;
-            index  index.html index.htm;
+            opentracing_operation_name "$request_method $uri";
+            opentracing_tag "resource.name" "/";
+            root /var/www/;
         }
 
         location /test {
-            opentracing_operation_name "nginx ${uri}";
-            root   html;
-            index  index.html index.htm;
+            opentracing_operation_name "$request_method $uri";
+            opentracing_tag "resource.name" "/test";
+            alias /var/www/index.html;
         }
     }
 }

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -42,7 +42,7 @@ cd curl-${CURL_VERSION}
             --disable-crypto-auth \
             --without-axtls \
             --disable-rtsp \
-            --enable-shared=yes \
+            --enable-shared=no \
             --enable-static=yes \
             --with-pic
 make && make install

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -11,7 +11,6 @@ namespace opentracing {
 
 // Accepts configuration in JSON format, with the following keys:
 // "service": Required. A string, the name of the service.
-// "span_name": Required. A string, the name of the spans.
 // "agent_host": A string, defaults to localhost.
 // "agent_port": A number, defaults to 8126.
 // "type": A string, defaults to web.

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -29,7 +29,7 @@ RUN make install
 FROM ubuntu:18.04
 
 ARG NGINX_VERSION=1.14.0
-ARG NGINX_OPENTRACING_VERSION=0.4.0
+ARG NGINX_OPENTRACING_VERSION=0.6.0
 
 RUN apt-get update && \
   apt-get install -y git gnupg lsb-release wget curl tar openjdk-8-jre golang jq


### PR DESCRIPTION
* Update nginx example. Moves from compiling the plugin from scratch to an actually useful example that shows how to use the release binaries.
* Update docs to reflect new example.
* Small fix to ensure libcurl is linked in statically.