### PR TITLE
Fix issue where a lack of context was considered an error

### DIFF
--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -139,10 +139,14 @@ ot::expected<std::unique_ptr<ot::SpanContext>> SpanContext::deserialize(
         }
         return {};
       });
-  if (!result) {  // "if unexpected", hence "{}" from above is fine.
+  if (!result) {  // "if unexpected", hence "return {}" from above is fine.
     return ot::make_unexpected(result.error());
   }
+  if (!trace_id_set && !parent_id_set) {
+    return {};  // Empty context/no context provided.
+  }
   if (!trace_id_set || !parent_id_set) {
+    // Partial context, this shouldn't happen.
     return ot::make_unexpected(ot::span_context_corrupted_error);
   }
   return std::move(

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -102,3 +102,24 @@ then
 fi
 
 kill_nginx
+# TEST 3: Check that creating a root span doesn't produce an error
+NGINX_ERROR_LOG=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--error-log-path=\([^ ]*\).*/\1/p')
+echo "" > ${NGINX_ERROR_LOG}
+run_nginx
+curl -s localhost?[1-5] 1> /dev/null
+
+if [ "$(cat ${NGINX_ERROR_LOG} | grep 'failed to extract an opentracing span context' | wc -l)" != "0" ]
+then
+  echo "Extraction errors in nginx log file:"
+  cat ${NGINX_ERROR_LOG}
+  echo ""
+  exit 1
+elif [ "$(cat ${NGINX_ERROR_LOG})" != "" ]
+then
+  echo "Other errors in nginx log file:"
+  cat ${NGINX_ERROR_LOG}
+  echo ""
+  exit 1
+fi
+
+kill_nginx

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -181,6 +181,40 @@ struct MockHandle : public Handle {
   std::condition_variable perform_called;
 };
 
+// A Mock TextMapReader and TextMapWriter.
+// Not in mocks.h since we only need it here for now.
+struct MockTextMapCarrier : ot::TextMapReader, ot::TextMapWriter {
+  MockTextMapCarrier() {}
+
+  ot::expected<void> Set(ot::string_view key, ot::string_view value) const override {
+    if (set_fails_after == 0) {
+      return ot::make_unexpected(std::error_code(6, ot::propagation_error_category()));
+    } else if (set_fails_after > 0) {
+      set_fails_after--;
+    }
+    text_map[key] = value;
+    return {};
+  }
+
+  ot::expected<ot::string_view> LookupKey(ot::string_view key) const override {
+    return ot::make_unexpected(ot::lookup_key_not_supported_error);
+  }
+
+  ot::expected<void> ForeachKey(
+      std::function<ot::expected<void>(ot::string_view key, ot::string_view value)> f)
+      const override {
+    for (const auto& key_value : text_map) {
+      auto result = f(key_value.first, key_value.second);
+      if (!result) return result;
+    }
+    return {};
+  }
+
+  mutable std::unordered_map<std::string, std::string> text_map;
+  // Count-down to method failing. Negative means no failures.
+  mutable int set_fails_after = -1;
+};
+
 }  // namespace opentracing
 }  // namespace datadog
 


### PR DESCRIPTION
Does this PR look [familiar](https://github.com/DataDog/dd-opentracing-cpp/pull/40)? I've not been having good luck today with my git fat-fingering.

* Made the original commits.
* Made a new branch for another issue.
* Realised the mistake, reverted the commits in the new branch so it had just it's own fixes.
* Merged that branch.
* Merged from master into this branch, thus reverting the commits and leaving the PR empty!
* Derp.

So this is the exact same PR as 40, except as penance for my sins I added an integration test in addition to the unit test.

Original PR description:

First bug from a customer!

> one more nit, every request is generating an unnecessary error log:
> ```2018/08/09 23:08:23 [error] 95#95: *23 failed to extract an opentracing span context from request 00007FED59C66050: opentracing: SpanContext data corrupted in Extract carrier```

This was caused by returning an error when no context was found, rather than an empty context. The behaviour worked correctly and generated the correct spans/traces, but printed an error.