### PR TITLE
Removing includes that should have been purged

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,8 +17,6 @@ cc_library(
         "src/span.h",
         "src/tracer.cpp",
         "src/tracer.h",
-        "src/transport.cpp",
-        "src/transport.h",
         "src/version_check.cpp",
         "src/version_check.h",
         "src/writer.cpp",

--- a/src/writer.h
+++ b/src/writer.h
@@ -1,7 +1,6 @@
 #ifndef DD_OPENTRACING_WRITER_H
 #define DD_OPENTRACING_WRITER_H
 
-#include <curl/curl.h>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -9,7 +8,6 @@
 #include <thread>
 #include "encoder.h"
 #include "span.h"
-#include "transport.h"
 
 namespace datadog {
 namespace opentracing {

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <sstream>
 #include <unordered_map>
+#include "../src/transport.h"
 #include "../src/writer.h"
 
 namespace datadog {


### PR DESCRIPTION
Trying to build from a basic ubuntu container with just-enough to compile envoy, and these missing headers were breaking that build.
They existed locally so no build errors occurred in the past.

(We can add CI for this when we upstream changes to envoy)