### PR TITLE
Adds language version number and better checking for library version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
     message(STATUS "Git version: ${VERSION}")
   else(GIT_FOUND)
     set(VERSION "unknown")
+    message(WARNING "Git missing, version number for this build is 'unknown'")
   endif(GIT_FOUND)
+else(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+  set(VERSION "unknown")
+  message(WARNING "Not being built from git repo, version number for this build is 'unknown'")
 endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
 configure_file(

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -9,7 +9,7 @@ AgentHttpEncoder::AgentHttpEncoder() {
   // Set up common headers and default encoder
   common_headers_ = {{"Content-Type", "application/msgpack"},
                      {"Datadog-Meta-Lang", "cpp"},
-                     {"Datadog-Meta-Lang-Version", __cplusplus},
+                     {"Datadog-Meta-Lang-Version", config::cpp_version},
                      {"Datadog-Meta-Tracer-Version", config::tracer_version}};
 }
 

--- a/src/version_number.h.in
+++ b/src/version_number.h.in
@@ -10,6 +10,7 @@ namespace opentracing {
 namespace config {
 
 const std::string tracer_version = VERSION;
+const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace config
 }  // namespace opentracing

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -69,6 +69,7 @@ TEST_CASE("writer") {
                                    {"Content-Type", "application/msgpack"},
                                    {"Datadog-Meta-Lang", "cpp"},
                                    {"Datadog-Meta-Tracer-Version", config::tracer_version},
+                                   {"Datadog-Meta-Lang-Version", config::cpp_version},
                                    {"X-Datadog-Trace-Count", "1"}});
   }
 
@@ -256,6 +257,7 @@ TEST_CASE("writer") {
                                      {"Content-Type", "application/msgpack"},
                                      {"Datadog-Meta-Lang", "cpp"},
                                      {"Datadog-Meta-Tracer-Version", config::tracer_version},
+                                     {"Datadog-Meta-Lang-Version", config::cpp_version},
                                      {"X-Datadog-Trace-Count", "3"}});
     }
   }


### PR DESCRIPTION
Thanks Alex :) 

It looks like "Datadog-Meta-Lang-Version : 201402"

In the future, maybe I can add compiler macros so we can see what's used.