### PR TITLE
Priority Sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
     message(STATUS "Git version: ${VERSION}")
   else(GIT_FOUND)
     set(VERSION "unknown")
+    message(WARNING "Git missing, version number for this build is 'unknown'")
   endif(GIT_FOUND)
+else(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+  set(VERSION "unknown")
+  message(WARNING "Not being built from git repo, version number for this build is 'unknown'")
 endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
 configure_file(

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -23,10 +23,16 @@ struct TracerOptions {
   // The type of service being traced.
   // (see above URL for definition)
   std::string type = "web";
-  // What percentage of traces are sent to the agent, real number in [0, 1].
+  // The environment this trace belongs to. eg. "" (env:none), "staging", "prod"
+  std::string environment = "";
+  // Client side sampling. The percentage of traces are sent to the agent, real number in [0, 1].
   // 0 = discard all traces, 1 = keep all traces.
   // Setting this lower reduces performance overhead at the cost of less data.
   double sample_rate = 1.0;
+  // If true, disables client-side sampling (thus ignoring sample_rate) and enables distributed
+  // priority sampling, where traces are sampled based on a combination of user-assigned priorities
+  // and configuration from the agent.
+  bool priority_sampling = false;
   // Max amount of time to wait between sending traces to agent, in ms. Agent discards traces older
   // than 10s, so that is the upper bound.
   int64_t write_period_ms = 1000;
@@ -44,12 +50,14 @@ class TraceEncoder {
 
   // Returns the Datadog Agent endpoint that traces should be sent to.
   virtual const std::string path() = 0;
-  virtual std::size_t pendingTraces() = 0;
+  virtual const std::size_t pendingTraces() = 0;
   virtual void clearTraces() = 0;
   // Returns the HTTP headers that are required for the collection of traces.
   virtual const std::map<std::string, std::string> headers() = 0;
   // Returns the encoded payload from the collection of traces.
   virtual const std::string payload() = 0;
+  // Receives and handles the response from the Agent.
+  virtual void handleResponse(const std::string &response) = 0;
 };
 
 // makeTracer returns an opentracing::Tracer that submits traces to the Datadog Agent.
@@ -58,7 +66,7 @@ std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options);
 // makeTracerAndEncoder initializes an opentracing::Tracer and provides an encoder
 // to use when submitting traces to the Datadog Agent.
 // This should be used in applications that need to also control the HTTP requests to the Datadog
-// Agent.
+// Agent. eg. Envoy
 std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTracerAndEncoder(
     const TracerOptions &options);
 

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -1,24 +1,34 @@
 #include "encoder.h"
+#include <nlohmann/json.hpp>
+#include "sample.h"
 #include "span.h"
 #include "version_number.h"
+
+using json = nlohmann::json;
 
 namespace datadog {
 namespace opentracing {
 
-AgentHttpEncoder::AgentHttpEncoder() {
+namespace {
+const std::string priority_sampling_key = "rate_by_service";
+}  // namespace
+
+AgentHttpEncoder::AgentHttpEncoder(std::shared_ptr<SampleProvider> sampler)
+    : /* May be nullptr if priority sampling disabled. */ sampler_(
+          std::dynamic_pointer_cast<PrioritySampler>(sampler)) {
   // Set up common headers and default encoder
   common_headers_ = {{"Content-Type", "application/msgpack"},
                      {"Datadog-Meta-Lang", "cpp"},
                      {"Datadog-Meta-Tracer-Version", config::tracer_version}};
 }
 
-const std::string agent_api_path = "/v0.3/traces";
+const std::string agent_api_path = "/v0.4/traces";
 
 const std::string AgentHttpEncoder::path() { return agent_api_path; }
 
 void AgentHttpEncoder::clearTraces() { traces_.clear(); }
 
-std::size_t AgentHttpEncoder::pendingTraces() { return traces_.size(); }
+const std::size_t AgentHttpEncoder::pendingTraces() { return traces_.size(); }
 
 const std::map<std::string, std::string> AgentHttpEncoder::headers() {
   std::map<std::string, std::string> headers(common_headers_);
@@ -34,6 +44,21 @@ const std::string AgentHttpEncoder::payload() {
 }
 
 void AgentHttpEncoder::addTrace(Trace trace) { traces_.push_back(std::move(trace)); }
+
+void AgentHttpEncoder::handleResponse(const std::string& response) {
+  if (sampler_ != nullptr) {
+    try {
+      json config = json::parse(response);
+      if (config.find(priority_sampling_key) == config.end()) {
+        return;  // No priority sampling info.
+      }
+      sampler_->configure(config[priority_sampling_key]);
+    } catch (const json::parse_error&) {
+      std::cerr << "Unable to parse response from agent" << std::endl;
+      return;
+    }
+  }
+}
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -2,28 +2,32 @@
 #define DD_OPENTRACING_ENCODER_H
 
 #include <datadog/opentracing.h>
-
 #include <sstream>
 
 namespace datadog {
 namespace opentracing {
 
+class SampleProvider;
+class PrioritySampler;
 struct SpanData;
 using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 
 class AgentHttpEncoder : public TraceEncoder {
  public:
-  AgentHttpEncoder();
+  // Accepts a SamplerProvider but only bothers keeping the pointer if it's a PrioritySampler,
+  // since other samplers do not need to interact with the Agent.
+  AgentHttpEncoder(std::shared_ptr<SampleProvider> sampler);
   ~AgentHttpEncoder() override {}
 
   // Returns the path that is used to submit HTTP requests to the agent.
   const std::string path() override;
-  std::size_t pendingTraces() override;
+  const std::size_t pendingTraces() override;
   void clearTraces() override;
   // Returns the HTTP headers that are required for the collection of traces.
   const std::map<std::string, std::string> headers() override;
   // Returns the encoded payload from the collection of traces.
   const std::string payload() override;
+  void handleResponse(const std::string& response) override;
   void addTrace(Trace trace);
 
  private:
@@ -31,6 +35,9 @@ class AgentHttpEncoder : public TraceEncoder {
   std::map<std::string, std::string> common_headers_;
   std::deque<Trace> traces_;
   std::stringstream buffer_;
+  // Responses from the Agent may contain configuration for the sampler. May be nullptr if priority
+  // sampling is not enabled.
+  std::shared_ptr<PrioritySampler> sampler_ = nullptr;
 };
 
 }  // namespace opentracing

--- a/src/noopspan.cpp
+++ b/src/noopspan.cpp
@@ -1,4 +1,5 @@
 #include "noopspan.h"
+#include "tracer.h"
 
 namespace ot = opentracing;
 

--- a/src/noopspan.h
+++ b/src/noopspan.h
@@ -2,8 +2,9 @@
 #define DD_OPENTRACING_NOOPSPAN_H
 
 #include <opentracing/span.h>
-
-#include "tracer.h"
+#include <opentracing/tracer.h>
+#include <memory>
+#include "propagation.h"
 
 namespace ot = opentracing;
 

--- a/src/opentracing_agent.cpp
+++ b/src/opentracing_agent.cpp
@@ -5,6 +5,7 @@
 
 #include <datadog/opentracing.h>
 #include "agent_writer.h"
+#include "sample.h"
 #include "tracer.h"
 
 namespace ot = opentracing;
@@ -13,10 +14,11 @@ namespace datadog {
 namespace opentracing {
 
 std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options) {
+  std::shared_ptr<SampleProvider> sampler = sampleProviderFromOptions(options);
   auto writer = std::shared_ptr<Writer>{
       new AgentWriter(options.agent_host, options.agent_port,
-                      std::chrono::milliseconds(llabs(options.write_period_ms)))};
-  return std::shared_ptr<ot::Tracer>{new Tracer{options, writer}};
+                      std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
+  return std::shared_ptr<ot::Tracer>{new Tracer{options, writer, sampler}};
 }
 
 }  // namespace opentracing

--- a/src/opentracing_external.cpp
+++ b/src/opentracing_external.cpp
@@ -6,6 +6,7 @@
 // See BAZEL.build for the files required to build this library using makeTracerAndEncoder.
 
 #include <datadog/opentracing.h>
+#include "sample.h"
 #include "tracer.h"
 #include "writer.h"
 
@@ -16,11 +17,12 @@ namespace opentracing {
 
 std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTracerAndEncoder(
     const TracerOptions &options) {
-  auto xwriter = std::make_shared<ExternalWriter>();
+  std::shared_ptr<SampleProvider> sampler = sampleProviderFromOptions(options);
+  auto xwriter = std::make_shared<ExternalWriter>(sampler);
   auto encoder = xwriter->encoder();
   std::shared_ptr<Writer> writer = xwriter;
   return std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>>{
-      std::shared_ptr<ot::Tracer>{new Tracer{options, writer}}, encoder};
+      std::shared_ptr<ot::Tracer>{new Tracer{options, writer, sampler}}, encoder};
 }
 
 }  // namespace opentracing

--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -37,7 +37,7 @@ bool has_prefix(const std::string &str, const std::string &prefix) {
 }  // namespace
 
 OptionalSamplingPriority asSamplingPriority(int i) {
-  if (i < -1 || i > 2) {
+  if (i < (int)SamplingPriority::MinimumValue || i > (int)SamplingPriority::MaximumValue) {
     return nullptr;
   }
   return std::make_unique<SamplingPriority>(static_cast<SamplingPriority>(i));
@@ -196,7 +196,7 @@ ot::expected<std::unique_ptr<ot::SpanContext>> SpanContext::deserialize(
             sampling_priority = asSamplingPriority(std::stoi(value));
             if (sampling_priority == nullptr) {
               // The sampling_priority key was present, but the value makes no sense.
-              std::cerr << "Invalid sampling_priority valule in serialized SpanContext"
+              std::cerr << "Invalid sampling_priority value in serialized SpanContext"
                         << std::endl;
               return ot::make_unexpected(ot::span_context_corrupted_error);
             }

--- a/src/propagation.h
+++ b/src/propagation.h
@@ -15,6 +15,9 @@ enum class SamplingPriority : int {
   SamplerDrop = 0,
   SamplerKeep = 1,
   UserKeep = 2,
+
+  MinimumValue = UserDrop,
+  MaximumValue = UserKeep,
 };
 
 // Move to std::optional in C++17 when it has better compiler support.

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -32,7 +32,7 @@ DiscardRateSampler::DiscardRateSampler(double rate)
 bool DiscardRateSampler::discard(const SpanContext& context) const {
   // I don't know how voodoo it is to use the trace_id essentially as a source of randomness,
   // rather than generating a new random number here. It's a bit faster, and more importantly it's
-  // cargo-culted from the agent. However it does still seem a little strange, and makes testing a
+  // cargo-culted from the agent. However it does still seem too "clever", and makes testing a
   // bit awkward.
   uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
   if (hashed_id < max_trace_id_) {
@@ -65,7 +65,7 @@ OptionalSamplingPriority PrioritySampler::sample(const std::string& environment,
   }
   // I don't know how voodoo it is to use the trace_id essentially as a source of randomness,
   // rather than generating a new random number here. It's a bit faster, and more importantly it's
-  // cargo-culted from the agent. However it does still seem a little strange, and makes testing a
+  // cargo-culted from the agent. However it does still seem too "clever", and makes testing a
   // bit awkward.
   uint64_t hashed_id = trace_id * constant_rate_hash_factor;
   if (hashed_id >= max_hash) {

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -1,4 +1,5 @@
 #include "sample.h"
+#include <sstream>
 
 namespace datadog {
 namespace opentracing {
@@ -12,55 +13,81 @@ const uint64_t constant_rate_hash_factor = 1111111111111111111;
 
 const std::string sample_rate_metric_key = "_sample_rate";
 
-SampleProvider KeepAllSampler() {
-  return {
-      [](SpanContext& context) {
-        context.setBaggageItem(sample_type_baggage_key, "KeepAllSampler");
-        return true;
-      },
-      [](std::unique_ptr<ot::Span>&) {},
-  };
-}
-
-SampleProvider DiscardAllSampler() {
-  return {
-      [](SpanContext& context) {
-        context.setBaggageItem(sample_type_baggage_key, "DiscardAllSampler");
-        return false;
-      },
-      [](std::unique_ptr<ot::Span>&) {},
-  };
-}
-
-SampleProvider ConstantRateSampler(double rate) {
-  uint64_t max_trace_id = 0;
+namespace {
+uint64_t maxIdFromKeepRate(double rate) {
   // This check is required to avoid undefined behaviour converting the rate back from
   // double to uint64_t.
   if (rate == 1.0) {
-    max_trace_id = std::numeric_limits<uint64_t>::max();
+    return std::numeric_limits<uint64_t>::max();
   } else if (rate > 0.0) {
-    max_trace_id = uint64_t(rate * max_trace_id_double);
+    return uint64_t(rate * max_trace_id_double);
+  }
+  return 0;
+}
+}  // namespace
+
+DiscardRateSampler::DiscardRateSampler(double rate)
+    : max_trace_id_(maxIdFromKeepRate(1.0 - rate)) {}
+
+bool DiscardRateSampler::discard(const SpanContext& context) const {
+  // I don't know how voodoo it is to use the trace_id essentially as a source of randomness,
+  // rather than generating a new random number here. It's a bit faster, and more importantly it's
+  // cargo-culted from the agent. However it does still seem a little strange, and makes testing a
+  // bit awkward.
+  uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
+  if (hashed_id < max_trace_id_) {
+    return false;
+  }
+  return true;
+}
+
+OptionalSamplingPriority DiscardRateSampler::sample(const std::string& environment,
+                                                    const std::string& service,
+                                                    uint64_t trace_id) const {
+  return nullptr;
+}
+
+bool PrioritySampler::discard(const SpanContext& context) const { return false; }
+
+OptionalSamplingPriority PrioritySampler::sample(const std::string& environment,
+                                                 const std::string& service,
+                                                 uint64_t trace_id) const {
+  uint64_t max_hash;
+  std::ostringstream key;
+  key << "service:" << service << ",env:" << environment;
+  {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto const rule = max_hash_by_service_env_.find(key.str());
+    if (rule == max_hash_by_service_env_.end()) {
+      return nullptr;
+    }
+    max_hash = rule->second;
+  }
+  // I don't know how voodoo it is to use the trace_id essentially as a source of randomness,
+  // rather than generating a new random number here. It's a bit faster, and more importantly it's
+  // cargo-culted from the agent. However it does still seem a little strange, and makes testing a
+  // bit awkward.
+  uint64_t hashed_id = trace_id * constant_rate_hash_factor;
+  if (hashed_id >= max_hash) {
+    return std::make_unique<SamplingPriority>(SamplingPriority::SamplerDrop);
   }
 
-  return {
-      [=](SpanContext& context) {
-        if (context.baggageItem(sample_type_baggage_key) != std::string{}) {
-          // Context already marked as sampled, so this span should be traced.
-          return true;
-        }
+  return std::make_unique<SamplingPriority>(SamplingPriority::SamplerKeep);
+}
 
-        // Apply the sample rate to all traces, new and existing (extracted from upstream).
-        uint64_t hashed_id = context.trace_id() * constant_rate_hash_factor;
-        if (hashed_id < max_trace_id) {
-          // Chosen for sampling. Add mark to context and return.
-          context.setBaggageItem(sample_type_baggage_key, "ConstantRateSampler");
-          return true;
-        }
-        // Not chosen for sampling.
-        return false;
-      },
-      [&, rate](std::unique_ptr<ot::Span>& span) { span->SetTag(sample_rate_metric_key, rate); },
-  };
+void PrioritySampler::configure(json config) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  max_hash_by_service_env_.clear();
+  for (json::iterator it = config.begin(); it != config.end(); ++it) {
+    max_hash_by_service_env_[it.key()] = maxIdFromKeepRate(it.value());
+  }
+}
+
+std::shared_ptr<SampleProvider> sampleProviderFromOptions(const TracerOptions& options) {
+  if (options.priority_sampling) {
+    return std::shared_ptr<SampleProvider>{new PrioritySampler()};
+  }
+  return std::shared_ptr<SampleProvider>{new DiscardRateSampler(1.0 - options.sample_rate)};
 }
 
 }  // namespace opentracing

--- a/src/sample.h
+++ b/src/sample.h
@@ -1,27 +1,72 @@
 #ifndef DD_OPENTRACING_SAMPLE_H
 #define DD_OPENTRACING_SAMPLE_H
 
-#include <functional>
+#include <datadog/opentracing.h>
+#include <opentracing/tracer.h>
 #include <iostream>
 #include <limits>
-
-#include <opentracing/tracer.h>
-
+#include <map>
+#include <mutex>
+#include <nlohmann/json.hpp>
 #include "propagation.h"
 
 namespace ot = opentracing;
+using json = nlohmann::json;
 
 namespace datadog {
 namespace opentracing {
 
-typedef struct {
-  std::function<bool(SpanContext&)> sample;
-  std::function<void(std::unique_ptr<ot::Span>&)> tag;
-} SampleProvider;
+class Span;
 
-SampleProvider KeepAllSampler();
-SampleProvider DiscardAllSampler();
-SampleProvider ConstantRateSampler(double rate);
+class SampleProvider {
+ public:
+  SampleProvider(){};
+  virtual ~SampleProvider() {}
+
+  virtual bool discard(const SpanContext& context) const = 0;
+  virtual OptionalSamplingPriority sample(const std::string& environment,
+                                          const std::string& service, uint64_t trace_id) const = 0;
+};
+
+class DiscardRateSampler : public SampleProvider {
+ public:
+  DiscardRateSampler(double rate);
+  ~DiscardRateSampler() override {}
+
+  bool discard(const SpanContext& context) const override;
+  OptionalSamplingPriority sample(const std::string& environment, const std::string& service,
+                                  uint64_t trace_id) const override;
+
+ protected:
+  uint64_t max_trace_id_ = 0;
+};
+
+class KeepAllSampler : public DiscardRateSampler {
+ public:
+  KeepAllSampler() : DiscardRateSampler(0) {}
+};
+
+class DiscardAllSampler : public DiscardRateSampler {
+ public:
+  DiscardAllSampler() : DiscardRateSampler(1) {}
+};
+
+class PrioritySampler : public SampleProvider {
+ public:
+  PrioritySampler() {}
+  ~PrioritySampler() override {}
+
+  bool discard(const SpanContext& context) const override;
+  OptionalSamplingPriority sample(const std::string& environment, const std::string& service,
+                                  uint64_t trace_id) const override;
+  void configure(json config);
+
+ private:
+  std::map<std::string, uint64_t> max_hash_by_service_env_;
+  mutable std::mutex mutex_;
+};
+
+std::shared_ptr<SampleProvider> sampleProviderFromOptions(const TracerOptions& options);
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/sample.h
+++ b/src/sample.h
@@ -56,10 +56,11 @@ class PrioritySampler : public SampleProvider {
   PrioritySampler() {}
   ~PrioritySampler() override {}
 
-  bool discard(const SpanContext& context) const override;
-  OptionalSamplingPriority sample(const std::string& environment, const std::string& service,
-                                  uint64_t trace_id) const override;
-  void configure(json config);
+  virtual bool discard(const SpanContext& context) const override;
+  virtual OptionalSamplingPriority sample(const std::string& environment,
+                                          const std::string& service,
+                                          uint64_t trace_id) const override;
+  virtual void configure(json config);
 
  private:
   std::map<std::string, uint64_t> max_hash_by_service_env_;

--- a/src/span.h
+++ b/src/span.h
@@ -2,15 +2,18 @@
 #define DD_OPENTRACING_SPAN_H
 
 #include <msgpack.hpp>
+#include "clock.h"
 #include "propagation.h"
-#include "tracer.h"
 
 namespace ot = opentracing;
 
 namespace datadog {
 namespace opentracing {
 
+extern const std::string environment_tag;
+
 class Tracer;
+class SampleProvider;
 class SpanBuffer;
 typedef std::function<uint64_t()> IdProvider;  // See tracer.h
 
@@ -47,24 +50,25 @@ struct SpanData {
   int64_t duration;
   int32_t error;
   std::unordered_map<std::string, std::string> meta;  // Aka, tags.
+  std::unordered_map<std::string, int> metrics;
 
   uint64_t traceId() const;
   uint64_t spanId() const;
+  const std::string env() const;
 
-  MSGPACK_DEFINE_MAP(name, service, resource, type, start, duration, meta, span_id, trace_id,
-                     parent_id, error)
+  MSGPACK_DEFINE_MAP(name, service, resource, type, start, duration, meta, metrics, span_id,
+                     trace_id, parent_id, error)
 };
-
-using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 
 // A Span, a component of a trace, a single instrumented event.
 class Span : public ot::Span {
  public:
   // Creates a new Span.
   Span(std::shared_ptr<const Tracer> tracer, std::shared_ptr<SpanBuffer> buffer,
-       TimeProvider get_time, uint64_t span_id, uint64_t trace_id, uint64_t parent_id,
-       SpanContext context, TimePoint start_time, std::string span_service, std::string span_type,
-       std::string span_name, std::string resource, std::string operation_name_override);
+       TimeProvider get_time, std::shared_ptr<SampleProvider> sampler, uint64_t span_id,
+       uint64_t trace_id, uint64_t parent_id, SpanContext context, TimePoint start_time,
+       std::string span_service, std::string span_type, std::string span_name,
+       std::string resource, std::string operation_name_override);
 
   Span() = delete;
   ~Span() override;
@@ -97,6 +101,7 @@ class Span : public ot::Span {
   std::shared_ptr<const Tracer> tracer_;
   std::shared_ptr<SpanBuffer> buffer_;
   TimeProvider get_time_;
+  std::shared_ptr<SampleProvider> sampler_;
   SpanContext context_;
   TimePoint start_time_;
   std::string operation_name_override_;

--- a/src/span.h
+++ b/src/span.h
@@ -94,7 +94,9 @@ class Span : public ot::Span {
   uint64_t spanId() const;
 
  private:
-  std::mutex mutex_;
+  void assignSamplingPriority() const;  // Sooo not const. See definition of method Span::context.
+
+  mutable std::mutex mutex_;
   std::atomic<bool> is_finished_{false};
 
   // Set in constructor initializer:
@@ -102,7 +104,7 @@ class Span : public ot::Span {
   std::shared_ptr<SpanBuffer> buffer_;
   TimeProvider get_time_;
   std::shared_ptr<SampleProvider> sampler_;
-  SpanContext context_;
+  mutable SpanContext context_;  // Mutable as a hack. See definition of method Span::context.
   TimePoint start_time_;
   std::string operation_name_override_;
 

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -1,6 +1,7 @@
 #include "span_buffer.h"
-
 #include <iostream>
+#include "span.h"
+#include "writer.h"
 
 namespace datadog {
 namespace opentracing {

--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -1,16 +1,18 @@
 #ifndef DD_OPENTRACING_SPAN_BUFFER_H
 #define DD_OPENTRACING_SPAN_BUFFER_H
 
-#include "span.h"
-#include "writer.h"
-
+#include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace datadog {
 namespace opentracing {
 
 class Writer;
+class SpanData;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 
 struct PendingTrace {
   PendingTrace()

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -58,7 +58,12 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
   // Get a new span id.
   auto span_id = get_id_();
 
-  auto span_context = SpanContext{span_id, span_id, nullptr /* No sampling_priority */, {}};
+  SpanContext span_context = SpanContext{span_id, span_id, nullptr /* No sampling_priority */, {}};
+  // See the comment in propagation.h on nginx_opentracing_compatibility_hack_.
+  if (operation_name == "dummySpan") {
+    span_context =
+        SpanContext::NginxOpenTracingCompatibilityHackSpanContext(span_id, span_id, nullptr, {});
+  }
   auto trace_id = span_id;
   auto parent_id = uint64_t{0};
 

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -2,15 +2,14 @@
 #define DD_OPENTRACING_TRACER_H
 
 #include <datadog/opentracing.h>
+#include <functional>
+#include <random>
 #include "clock.h"
 #include "encoder.h"
 #include "sample.h"
 #include "span.h"
 #include "span_buffer.h"
 #include "writer.h"
-
-#include <functional>
-#include <random>
 
 namespace ot = opentracing;
 
@@ -28,13 +27,14 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
  public:
   // Creates a Tracer by copying the given options and injecting the given dependencies.
   Tracer(TracerOptions options, std::shared_ptr<SpanBuffer> buffer, TimeProvider get_time,
-         IdProvider get_id, SampleProvider sample);
+         IdProvider get_id, std::shared_ptr<SampleProvider> sampler);
 
   // Creates a Tracer by copying the given options and using the preconfigured writer.
   // The writer is either an AgentWriter that sends trace data directly to the Datadog Agent, or
   // an ExternalWriter that requires an external HTTP client to encode and submit to the Datadog
   // Agent.
-  Tracer(TracerOptions options, std::shared_ptr<Writer> &writer);
+  Tracer(TracerOptions options, std::shared_ptr<Writer> &writer,
+         std::shared_ptr<SampleProvider> sampler);
 
   Tracer() = delete;
 
@@ -69,7 +69,7 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   std::shared_ptr<SpanBuffer> buffer_;
   TimeProvider get_time_;
   IdProvider get_id_;
-  SampleProvider sampler_;
+  std::shared_ptr<SampleProvider> sampler_;
 };
 
 }  // namespace opentracing

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -15,14 +15,19 @@ namespace opentracing {
 // "agent_host": A string, defaults to localhost.
 // "agent_port": A number, defaults to 8126.
 // "type": A string, defaults to web.
+// "environment": A string, defaults to "". The environment this trace belongs to.
+//     eg. "" (env:none), "staging", "prod"
 // "sample_rate": A double, defaults to 1.0.
+// "dd.priority.sampling": A boolean, false by default. If true disables client-side sampling (thus
+//     ignoring sample_rate) and enables distributed priority sampling, where traces are sampled
+//     based on a combination of user-assigned priorities and configuration from the agent.
 // "operation_name_override": A string, if not empty it overrides the operation name (and the
 //     overridden operation name is recorded in the tag "operation").
 // Extra keys will be ignored.
 template <class TracerImpl>
 ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
     const char *configuration, std::string &error_message) const noexcept try {
-  TracerOptions options{"localhost", 8126, "", "web", 1.0};
+  TracerOptions options{"localhost", 8126, "", "web", "", 1.0};
   json config;
   try {
     config = json::parse(configuration);
@@ -47,8 +52,14 @@ ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
     if (config.find("type") != config.end()) {
       options.type = config["type"];
     }
+    if (config.find("environment") != config.end()) {
+      options.environment = config["environment"];
+    }
     if (config.find("sample_rate") != config.end()) {
       options.sample_rate = config["sample_rate"];
+    }
+    if (config.find("dd.priority.sampling") != config.end()) {
+      options.priority_sampling = config["dd.priority.sampling"];
     }
     if (config.find("operation_name_override") != config.end()) {
       options.operation_name_override = config["operation_name_override"];
@@ -57,11 +68,12 @@ ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
     error_message = "configuration has an argument with an incorrect type";
     return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));
   }
+  std::shared_ptr<SampleProvider> sampler = sampleProviderFromOptions(options);
   auto writer = std::shared_ptr<Writer>{
       new AgentWriter(options.agent_host, options.agent_port,
-                      std::chrono::milliseconds(llabs(options.write_period_ms)))};
+                      std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
 
-  return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer}};
+  return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};
 } catch (const std::bad_alloc &) {
   return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
 }

--- a/src/version_check.cpp
+++ b/src/version_check.cpp
@@ -1,6 +1,5 @@
-#include <stdexcept>
-
 #include "version_check.h"
+#include <stdexcept>
 
 namespace datadog {
 namespace opentracing {

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -1,12 +1,14 @@
 #include "writer.h"
 #include <iostream>
 #include "encoder.h"
+#include "span.h"
 #include "version_number.h"
 
 namespace datadog {
 namespace opentracing {
 
-Writer::Writer() : trace_encoder_(std::make_shared<AgentHttpEncoder>()) {}
+Writer::Writer(std::shared_ptr<SampleProvider> sampler)
+    : trace_encoder_(std::make_shared<AgentHttpEncoder>(sampler)) {}
 
 void ExternalWriter::write(Trace trace) { trace_encoder_->addTrace(std::move(trace)); }
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -8,16 +8,21 @@
 #include <sstream>
 #include <thread>
 #include "encoder.h"
-#include "span.h"
-#include "transport.h"
+// #include "transport.h"
 
 namespace datadog {
 namespace opentracing {
 
+class SampleProvider;
+class AgentHttpEncoder;
+class TraceEncoder;
+struct SpanData;
+using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
+
 // A Writer is used to submit completed traces to the Datadog agent.
 class Writer {
  public:
-  Writer();
+  Writer(std::shared_ptr<SampleProvider> sampler);
 
   virtual ~Writer() {}
 
@@ -32,7 +37,7 @@ class Writer {
 // to the Datadog Agent.
 class ExternalWriter : public Writer {
  public:
-  ExternalWriter() {}
+  ExternalWriter(std::shared_ptr<SampleProvider> sampler) : Writer(sampler) {}
   ~ExternalWriter() override {}
 
   // Implements Writer methods.

--- a/test/integration/nginx/expected.json
+++ b/test/integration/nginx/expected.json
@@ -3,7 +3,6 @@
     {
       "error": 0,
       "meta": {
-        "_sample_rate": "1.000000",
         "component": "nginx",
         "http.method": "GET",
         "http.status_code": "200",
@@ -11,6 +10,7 @@
         "http.url": "http://localhost/",
         "operation": "GET /index.html"
       },
+      "metrics": {},
       "name": "nginx.handle",
       "resource": "/",
       "service": "nginx",
@@ -21,7 +21,6 @@
     {
       "error": 0,
       "meta": {
-        "_sample_rate": "1.000000",
         "component": "nginx",
         "http.method": "GET",
         "http.status_code": "200",
@@ -29,6 +28,7 @@
         "http.url": "http://localhost/",
         "operation": "GET /index.html"
       },
+      "metrics": {},
       "name": "nginx.handle",
       "resource": "/",
       "service": "nginx",
@@ -39,7 +39,6 @@
     {
       "error": 0,
       "meta": {
-        "_sample_rate": "1.000000",
         "component": "nginx",
         "http.method": "GET",
         "http.status_code": "200",
@@ -47,6 +46,7 @@
         "http.url": "http://localhost/",
         "operation": "GET /index.html"
       },
+      "metrics": {},
       "name": "nginx.handle",
       "resource": "/",
       "service": "nginx",

--- a/test/integration/nginx/nginx.conf
+++ b/test/integration/nginx/nginx.conf
@@ -20,5 +20,12 @@ http {
             opentracing_tag "resource.name" "/";
             root   /var/www;
         }
+
+        location /proxy/ {
+            opentracing_operation_name "$request_method $uri";
+            opentracing_tag "resource.name" "/proxy/";
+            opentracing_propagate_context;
+            proxy_pass http://127.0.0.1:8080;
+        }
     }
 }

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -21,7 +21,7 @@ dict getBaggage(SpanContext* ctx) {
 
 TEST_CASE("SpanContext") {
   MockTextMapCarrier carrier{};
-  SpanContext context{420, 123, {{"ayy", "lmao"}, {"hi", "haha"}}};
+  SpanContext context{420, 123, nullptr, {{"ayy", "lmao"}, {"hi", "haha"}}};
 
   SECTION("can be serialized") {
     REQUIRE(context.serialize(carrier));

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -1,4 +1,5 @@
 #include "../src/sample.h"
+#include "../src/agent_writer.h"
 #include "../src/span.h"
 #include "../src/tracer.h"
 #include "mocks.h"
@@ -93,5 +94,137 @@ TEST_CASE("sample") {
     REQUIRE(root_span->traceId() == child_span->traceId());
     // The span id should be different.
     REQUIRE(root_span->spanId() != child_span->spanId());
+  }
+}
+
+TEST_CASE("priority sampler unit test") {
+  PrioritySampler sampler;
+
+  SECTION("doesn't discard") {
+    for (const SpanContext &ctx :
+         {SpanContext{1, 1, nullptr, {}}, SpanContext{1, 2, asSamplingPriority(-1), {}},
+          SpanContext{1, 2, asSamplingPriority(0), {}},
+          SpanContext{1, 2, asSamplingPriority(1), {}},
+          SpanContext{1, 2, asSamplingPriority(2), {}}}) {
+      REQUIRE(!sampler.discard(ctx));
+    }
+  }
+
+  SECTION("default unconfigured sampling behaviour is to not apply any priority sampling") {
+    REQUIRE(sampler.sample("", "", 0) == nullptr);
+    REQUIRE(sampler.sample("env", "service", 1) == nullptr);
+  }
+
+  SECTION("configured") {
+    sampler.configure("{ \"service:nginx,env:\": 0.8, \"service:nginx,env:prod\": 0.2 }"_json);
+
+    SECTION("spans that don't match a rule are not given a sampling priority") {
+      REQUIRE(sampler.sample("different env", "different service", 1) == nullptr);
+    }
+
+    SECTION("spans can be sampled") {
+      // Case 1, service:nginx,env: => 0.8
+      int count_sampled = 0;
+      int total = 10000;
+      for (int i = 0; i < total; i++) {
+        auto p = sampler.sample("", "nginx", getId());
+        REQUIRE(p != nullptr);
+        REQUIRE(((*p == SamplingPriority::SamplerKeep) || (*p == SamplingPriority::SamplerDrop)));
+        count_sampled += *p == SamplingPriority::SamplerKeep ? 1 : 0;
+      }
+      double sample_rate = count_sampled / (double)total;
+      REQUIRE((sample_rate < 0.85 && sample_rate > 0.75));
+      // Case 2, service:nginx,env:prod => 0.2
+      count_sampled = 0;
+      total = 10000;
+      for (int i = 0; i < total; i++) {
+        auto p = sampler.sample("", "nginx", getId());
+        REQUIRE(p != nullptr);
+        REQUIRE(((*p == SamplingPriority::SamplerKeep) || (*p == SamplingPriority::SamplerDrop)));
+        count_sampled += *p == SamplingPriority::SamplerKeep ? 1 : 0;
+      }
+      sample_rate = count_sampled / (double)total;
+      REQUIRE((sample_rate < 0.85 && sample_rate > 0.75));
+    }
+  }
+}
+
+TEST_CASE("correct sampler is used") {
+  TracerOptions tracer_options{"", 0, "service_name", "web"};
+
+  SECTION("rate sampler") {
+    tracer_options.sample_rate = 0.4;
+    auto sampler = sampleProviderFromOptions(tracer_options);
+    REQUIRE(std::dynamic_pointer_cast<DiscardRateSampler>(sampler));
+  }
+
+  SECTION("priority sampler") {
+    tracer_options.priority_sampling = true;
+    auto sampler = sampleProviderFromOptions(tracer_options);
+    REQUIRE(std::dynamic_pointer_cast<PrioritySampler>(sampler));
+  }
+}
+
+TEST_CASE("priority sampler \"integration\" test") {
+  // There's a real integration test! It's in ./integration/nginx
+  // This tests the interaction between Span and the sampler. It's a bit of an overlap with the
+  // tests in span_test.cpp.
+  TracerOptions tracer_options{"", 0, "service_name", "web"};
+  tracer_options.environment = "threatened by climate change";
+  tracer_options.priority_sampling = true;
+  auto sampler = sampleProviderFromOptions(tracer_options);
+  REQUIRE(std::dynamic_pointer_cast<PrioritySampler>(sampler));
+
+  std::unique_ptr<MockHandle> handle_ptr{new MockHandle{}};
+  MockHandle *handle = handle_ptr.get();
+  auto only_send_traces_when_we_flush = std::chrono::seconds(3600);
+  auto writer = std::make_shared<AgentWriter>(
+      std::move(handle_ptr), only_send_traces_when_we_flush, 11000 /* max queued traces */,
+      std::vector<std::chrono::milliseconds>{}, "hostname", 6319, sampler);
+  auto buffer = std::make_shared<WritingSpanBuffer>(writer);
+
+  std::shared_ptr<Tracer> tracer{new Tracer{tracer_options, buffer, getRealTime, getId, sampler}};
+  const ot::StartSpanOptions span_options;
+  const ot::FinishSpanOptions finish_options;
+
+  // First, configure the PrioritySampler. Send a trace to the agent, and have the agent reply with
+  // the config.
+  handle->response = R"( {
+    "rate_by_service": {
+      "service:service_name,env:threatened by climate change": 0.3,
+      "service:wrong,env:threatened by climate change": 0.1,
+      "service:service_name,env:wrong": 0.5
+    }
+  } )";
+
+  auto span = tracer->StartSpanWithOptions("operation_name", span_options);
+  span->FinishWithOptions(finish_options);
+  writer->flush();
+  handle->response = "";
+
+  SECTION("sampling rate is applied") {
+    // Start a heap of spans.
+    int total = 10000;
+    int count_sampled = 0;
+    for (int i = 0; i < total; i++) {
+      auto span = tracer->StartSpanWithOptions("operation_name", span_options);
+      span->FinishWithOptions(finish_options);
+    }
+    writer->flush();
+    // Check the spans, and the rate at which they were sampled.
+    auto traces = handle->getTraces();
+    REQUIRE(traces->size() == total);
+    for (const auto &trace : *traces) {
+      REQUIRE(trace.size() == 1);
+      std::cout << json(trace[0].metrics).dump() << std::endl;
+      REQUIRE(trace[0].metrics.find("_sampling_priority_v1") != trace[0].metrics.end());
+      OptionalSamplingPriority p =
+          asSamplingPriority(trace[0].metrics.find("_sampling_priority_v1")->second);
+      REQUIRE(p != nullptr);
+      REQUIRE(((*p == SamplingPriority::SamplerKeep) || (*p == SamplingPriority::SamplerDrop)));
+      count_sampled += *p == SamplingPriority::SamplerKeep ? 1 : 0;
+    }
+    double sample_rate = count_sampled / (double)total;
+    REQUIRE((sample_rate < 0.35 && sample_rate > 0.25));
   }
 }

--- a/test/span_buffer_test.cpp
+++ b/test/span_buffer_test.cpp
@@ -1,4 +1,5 @@
 #include "../src/span_buffer.h"
+#include "../src/sample.h"
 #include "mocks.h"
 
 #define CATCH_CONFIG_MAIN
@@ -6,7 +7,8 @@
 using namespace datadog::opentracing;
 
 TEST_CASE("span buffer") {
-  auto writer_ptr = std::make_shared<MockWriter>();
+  auto sampler = std::make_shared<KeepAllSampler>();
+  auto writer_ptr = std::make_shared<MockWriter>(sampler);
   MockWriter* writer = writer_ptr.get();
   WritingSpanBuffer buffer{writer_ptr};
 

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -12,7 +12,9 @@ using namespace datadog::opentracing;
 struct MockTracer : public ot::Tracer {
   TracerOptions opts;
 
-  MockTracer(TracerOptions opts_, std::shared_ptr<Writer> &writer) : opts(opts_) {}
+  MockTracer(TracerOptions opts_, std::shared_ptr<Writer> &writer,
+             std::shared_ptr<SampleProvider> sampler)
+      : opts(opts_) {}
 
   std::unique_ptr<ot::Span> StartSpanWithOptions(ot::string_view operation_name,
                                                  const ot::StartSpanOptions &options) const

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -1,8 +1,8 @@
+#include "../src/tracer.h"
+#include <ctime>
 #include "../src/sample.h"
 #include "../src/span.h"
 #include "mocks.h"
-
-#include <ctime>
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
@@ -16,7 +16,7 @@ TEST_CASE("tracer") {
   auto buffer = new MockBuffer();
   TimeProvider get_time = [&time]() { return time; };  // Mock clock.
   IdProvider get_id = [&id]() { return id++; };        // Mock ID provider.
-  SampleProvider sampler = KeepAllSampler();
+  auto sampler = std::make_shared<KeepAllSampler>();
   TracerOptions tracer_options{"", 0, "service_name", "web"};
   std::shared_ptr<Tracer> tracer{
       new Tracer{tracer_options, std::shared_ptr<SpanBuffer>{buffer}, get_time, get_id, sampler}};
@@ -47,7 +47,7 @@ TEST_CASE("tracer") {
 
   SECTION("span context is propagated") {
     MockTextMapCarrier carrier;
-    SpanContext context{420, 69, {{"ayy", "lmao"}, {"hi", "haha"}}};
+    SpanContext context{420, 69, nullptr, {{"ayy", "lmao"}, {"hi", "haha"}}};
     auto success = tracer->Inject(context, carrier);
     REQUIRE(success);
     auto span_context_maybe = tracer->Extract(carrier);


### PR DESCRIPTION
Adds priority sampling.

- New config options; "dd.priority.sampling" (bool) to enable it, "environment" (string) to supply the environment name.
- Sampling class hierarchy/design overhauled. Sorry I got rid of your (really very neat) struct-of-closures Caleb; but with Priority Sampling there was a need to store state for the sampler. So I made the boring decision to use a normal class for this, thus making the whole thing an inheritance hierarchy.
- Responses from sending traces to the Agent are now recorded, the `rate_by_service` sampling priority map is extracted and used to configure the PrioritySampler. Lots of new plumbing needed for this, such as Encoder having to store a pointer to the PrioritySampler so that responses can be sent (and therefore the PrioritySampler has to be threaded through a few different constructors on the way).
- Priority Sampling is decided at span Finish, to wait for a user to tag it if they so wish. SpanContext now has an OptionalSamplingPriority, that is serialised/deserialised so it can propagate.
- The original type of client-side sampling we were doing has been renamed to 'discard' sampling, works the same, but doesn't do any of the pseudo-propagation via baggage any more. 
- Integration test neatened up a bit, and a test added for priority sampling.

Sorry it's a bit of a big one. The plumbing changes needed created a lot of boilerplate delta.

TODO: 
 - Allow users to set SamplingPriority on any span, have it propagate to root span (as long as no propagation).