### PR TITLE
Add support for propagation via C++ streams

### DIFF
--- a/src/propagation.h
+++ b/src/propagation.h
@@ -46,11 +46,13 @@ class SpanContext : public ot::SpanContext {
   std::string baggageItem(ot::string_view key) const;
 
   // Serializes the context into the given writer.
+  ot::expected<void> serialize(std::ostream &writer) const;
   ot::expected<void> serialize(const ot::TextMapWriter &writer) const;
 
   SpanContext withId(uint64_t id) const;
 
   // Returns a new context from the given reader.
+  static ot::expected<std::unique_ptr<ot::SpanContext>> deserialize(std::istream &reader);
   static ot::expected<std::unique_ptr<ot::SpanContext>> deserialize(
       const ot::TextMapReader &reader);
 

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
 }
 
 ot::expected<void> Tracer::Inject(const ot::SpanContext &sc, std::ostream &writer) const {
-  return ot::make_unexpected(ot::invalid_carrier_error);
+  return inject(sc, writer);
 }
 
 ot::expected<void> Tracer::Inject(const ot::SpanContext &sc,
@@ -111,19 +111,8 @@ ot::expected<void> Tracer::Inject(const ot::SpanContext &sc,
   return inject(sc, writer);
 }
 
-ot::expected<void> Tracer::inject(const ot::SpanContext &sc, const ot::TextMapWriter &writer) const
-    try {
-  auto span_context = dynamic_cast<const SpanContext *>(&sc);
-  if (span_context == nullptr) {
-    return ot::make_unexpected(ot::invalid_span_context_error);
-  }
-  return span_context->serialize(writer);
-} catch (const std::bad_alloc &) {
-  return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
-}
-
 ot::expected<std::unique_ptr<ot::SpanContext>> Tracer::Extract(std::istream &reader) const {
-  return ot::make_unexpected(ot::invalid_carrier_error);
+  return SpanContext::deserialize(reader);
 }
 
 ot::expected<std::unique_ptr<ot::SpanContext>> Tracer::Extract(

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -62,7 +62,16 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   void Close() noexcept override;
 
  private:
-  ot::expected<void> inject(const ot::SpanContext &sc, const ot::TextMapWriter &writer) const;
+  template <class Writer>
+  ot::expected<void> inject(const ot::SpanContext &sc, Writer &writer) const try {
+    auto span_context = dynamic_cast<const SpanContext *>(&sc);
+    if (span_context == nullptr) {
+      return ot::make_unexpected(ot::invalid_span_context_error);
+    }
+    return span_context->serialize(writer);
+  } catch (const std::bad_alloc &) {
+    return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
+  }
 
   const TracerOptions opts_;
   // Keeps finished spans until their entire trace is finished.

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -92,3 +92,26 @@ TEST_CASE("SpanContext") {
     }
   }
 }
+
+TEST_CASE("Binary Span Context") {
+  std::stringstream carrier{};
+  SpanContext context{420,
+                      123,
+                      std::make_unique<SamplingPriority>(SamplingPriority::SamplerKeep),
+                      {{"ayy", "lmao"}, {"hi", "haha"}}};
+
+  SECTION("can be serialized") {
+    REQUIRE(context.serialize(carrier));
+
+    SECTION("can be deserialized") {
+      auto sc = SpanContext::deserialize(carrier);
+      auto received_context = dynamic_cast<SpanContext*>(sc->get());
+      REQUIRE(received_context);
+      REQUIRE(received_context->id() == 420);
+      REQUIRE(received_context->trace_id() == 123);
+      REQUIRE(received_context->getSamplingPriority() != nullptr);
+      REQUIRE(*received_context->getSamplingPriority() == SamplingPriority::SamplerKeep);
+      REQUIRE(getBaggage(received_context) == dict{{"ayy", "lmao"}, {"hi", "haha"}});
+    }
+  }
+}


### PR DESCRIPTION
This adds support for "binary" context propagation.

To keep things simple, JSON is the format used for encoding the span details when using this propagation method.