### PR TITLE
Fix support for multiple artifacts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,7 +92,7 @@ ARTIFACT_URLS=$(curl -s https://circleci.com/api/v1.1/project/github/DataDog/dd-
 rm -rf .bin
 mkdir .bin
 cd .bin
-echo $ARTIFACT_URLS | while read ARTIFACT_URL
+echo "${ARTIFACT_URLS}" | while read ARTIFACT_URL
   do
     echo "Downloading artifact: ${ARTIFACT_URL}"
     curl -s -O ${ARTIFACT_URL}


### PR DESCRIPTION
Without the quotes it was generating an array which is fine, but which doesn't work with read.