### PR TITLE
Fixes errors and warnings when building with bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,8 +17,6 @@ cc_library(
         "src/span.h",
         "src/tracer.cpp",
         "src/tracer.h",
-        "src/version_check.cpp",
-        "src/version_check.h",
         "src/writer.cpp",
         "src/writer.h",
         ":version_number.h",

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -50,7 +50,7 @@ class TraceEncoder {
 
   // Returns the Datadog Agent endpoint that traces should be sent to.
   virtual const std::string path() = 0;
-  virtual const std::size_t pendingTraces() = 0;
+  virtual std::size_t pendingTraces() = 0;
   virtual void clearTraces() = 0;
   // Returns the HTTP headers that are required for the collection of traces.
   virtual const std::map<std::string, std::string> headers() = 0;

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -29,7 +29,7 @@ const std::string AgentHttpEncoder::path() { return agent_api_path; }
 
 void AgentHttpEncoder::clearTraces() { traces_.clear(); }
 
-const std::size_t AgentHttpEncoder::pendingTraces() { return traces_.size(); }
+std::size_t AgentHttpEncoder::pendingTraces() { return traces_.size(); }
 
 const std::map<std::string, std::string> AgentHttpEncoder::headers() {
   std::map<std::string, std::string> headers(common_headers_);

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -21,7 +21,7 @@ class AgentHttpEncoder : public TraceEncoder {
 
   // Returns the path that is used to submit HTTP requests to the agent.
   const std::string path() override;
-  const std::size_t pendingTraces() override;
+  std::size_t pendingTraces() override;
   void clearTraces() override;
   // Returns the HTTP headers that are required for the collection of traces.
   const std::map<std::string, std::string> headers() override;

--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -68,11 +68,11 @@ SpanContext SpanContext::NginxOpenTracingCompatibilityHackSpanContext(
 }
 
 SpanContext::SpanContext(SpanContext &&other)
-    : id_(other.id_),
+    : nginx_opentracing_compatibility_hack_(other.nginx_opentracing_compatibility_hack_),
+      id_(other.id_),
       trace_id_(other.trace_id_),
       sampling_priority_(std::move(other.sampling_priority_)),
-      baggage_(std::move(other.baggage_)),
-      nginx_opentracing_compatibility_hack_(other.nginx_opentracing_compatibility_hack_) {}
+      baggage_(std::move(other.baggage_)) {}
 
 SpanContext &SpanContext::operator=(SpanContext &&other) {
   std::lock_guard<std::mutex> lock{mutex_};


### PR DESCRIPTION
Errors:
```
ERROR: missing input file '//:src/version_check.cpp'
ERROR: /home/ubuntu/datadog/dd-opentracing-cpp/BUILD.bazel:1:1: //:dd_opentracing_cpp: missing input file '//:src/version_check.cpp'
```
and
```
bazel-out/k8-fastbuild/bin/external/com_github_datadog_dd_opentracing_cpp/_virtual_includes/dd_opentracing_cpp/datadog/opentracing.h:53:47: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
   virtual const std::size_t pendingTraces() = 0;
```
Warnings:
```
src/propagation.h:86:48: warning: 'datadog::opentracing::SpanContext::baggage_' will be initialized after [-Wreorder]
   std::unordered_map<std::string, std::string> baggage_;
                                                ^
src/propagation.h:81:48: warning:   'bool datadog::opentracing::SpanContext::nginx_opentracing_compatibility_hack_' [-Wreorder]
   bool nginx_opentracing_compatibility_hack_ = false;
```