### PR TITLE
Better static behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 # Dependencies
 find_path(OPENTRACING_INCLUDE_DIR NAMES opentracing/tracer.h)
 find_library(OPENTRACING_LIB opentracing)
+find_package(ZLIB REQUIRED)
 find_library(MSGPACK_LIB msgpack)
 find_package(CURL)
 find_package(Threads REQUIRED)
@@ -56,7 +57,7 @@ find_package(Threads REQUIRED)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/3rd_party/sanitizers-cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 
-set(DATADOG_LINK_LIBRARIES ${OPENTRACING_LIB} ${CURL_LIBRARIES} Threads::Threads)
+set(DATADOG_LINK_LIBRARIES ${OPENTRACING_LIB} ${CURL_LIBRARIES} ${ZLIB_LIBRARIES} Threads::Threads)
 
 # Includes
 include_directories(SYSTEM 3rd_party/include)
@@ -70,11 +71,6 @@ file(GLOB DD_OPENTRACING_SOURCES "src/*.cpp")
 # Outputs
 ## Shared lib
 if(BUILD_SHARED)
-  # Needed for curl if: curl is built statically, we compile a shared lib, and an nginx build
-  # is happening on the same machine. Using zlib1-dev from repos causes a linker fail.
-  find_package(ZLIB)
-  set(DATADOG_LINK_LIBRARIES ${OPENTRACING_LIB} ${ZLIB_LIBRARIES} ${CURL_LIBRARIES} Threads::Threads)
-
   add_library(dd_opentracing SHARED ${DD_OPENTRACING_SOURCES})
   add_sanitizers(dd_opentracing)
   target_link_libraries(dd_opentracing ${DATADOG_LINK_LIBRARIES})

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -48,26 +48,26 @@ if [ "$BUILD_OPENTRACING" -eq "1" ]; then
   cd ../..
 fi
 
+# Zlib
+if [ "$BUILD_ZLIB" -eq "1" ]; then
+  wget https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+  tar zxf zlib-${ZLIB_VERSION}.tar.gz
+  cd zlib-${ZLIB_VERSION}
+  CFLAGS="$CFLAGS -fPIC" ./configure --static
+  make && make install
+  cd ..
+fi
+
 # Msgpack
 if [ "$BUILD_MSGPACK" -eq "1" ]; then
   wget https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz -O msgpack.tar.gz
   tar zxvf msgpack.tar.gz
   mkdir msgpack-${MSGPACK_VERSION}/.build
   cd msgpack-${MSGPACK_VERSION}/.build
-  cmake ..
+  cmake -DBUILD_SHARED_LIBS=OFF ..
   make
   make install
   cd ../..
-fi
-
-# Zlib
-if [ "$BUILD_ZLIB" -eq "1" ]; then
-  wget https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
-  tar zxf zlib-${ZLIB_VERSION}.tar.gz
-  cd zlib-${ZLIB_VERSION}
-  ./configure --static
-  make && make install
-  cd ..
 fi
 
 # Libcurl
@@ -86,6 +86,7 @@ if [ "$BUILD_CURL" -eq "1" ]; then
               --without-ssl \
               --disable-crypto-auth \
               --without-axtls \
+              --with-zlib \
               --disable-rtsp \
               --enable-shared=no \
               --enable-static=yes \

--- a/src/span.cpp
+++ b/src/span.cpp
@@ -90,8 +90,14 @@ namespace {
 // Matches path segments with numbers (except things that look like versions).
 // Similar to, but not the same as,
 // https://github.com/datadog/dd-trace-java/blob/master/dd-trace-ot/src/main/java/datadog/opentracing/decorators/URLAsResourceName.java#L14-L16
-std::regex PATH_MIXED_ALPHANUMERICS{
-    "(\\/)(?:(?:([^?\\/&]*)(?:\\?[^\\/]+))|(?:(?![vV]\\d{1,2}\\/)[^\\/\\d\\?]*[\\d-]+[^\\/]*))"};
+std::regex &PATH_MIXED_ALPHANUMERICS() {
+  // Don't statically initialize a complex object.
+  // Thread safe as of C++11, as long as it's not reentrant.
+  static std::regex r{
+      "(\\/)(?:(?:([^?\\/&]*)(?:\\?[^\\/]+))|(?:(?![vV]\\d{1,2}\\/)[^\\/"
+      "\\d\\?]*[\\d-]+[^\\/]*))"};
+  return r;
+}
 }  // namespace
 
 // Imperfectly audits the data in a Span, removing some things that could cause information leaks
@@ -101,7 +107,7 @@ std::regex PATH_MIXED_ALPHANUMERICS{
 void audit(SpanData *span) {
   auto http_tag = span->meta.find(http_url_tag);
   if (http_tag != span->meta.end()) {
-    http_tag->second = std::regex_replace(http_tag->second, PATH_MIXED_ALPHANUMERICS, "$1$2?");
+    http_tag->second = std::regex_replace(http_tag->second, PATH_MIXED_ALPHANUMERICS(), "$1$2?");
   }
 }
 


### PR DESCRIPTION
Two definitions of static!

* Firstly, link libz so it can be used by curl
* Secondly, avoid static initialization of regex (which seems to sometimes fail when library loaded via dlopen)
