### PR TITLE
Fix mismatched tag from refactoring.

### DIFF
--- a/src/propagation.h
+++ b/src/propagation.h
@@ -12,7 +12,6 @@ namespace opentracing {
 
 class SpanBuffer;
 class SampleProvider;
-class SpanData;
 
 enum class SamplingPriority : int {
   UserDrop = -1,


### PR DESCRIPTION
This caused an error when running some (not all) of the tests in envoy's CI for our submission.