### PR TITLE
Use clang-5.0 for bazel compile stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
   docker:
-    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_3
+    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_4
 
 jobs:
   build:
@@ -43,6 +43,8 @@ jobs:
       - run:
           name: Build (with bazel)
           command: |
+            export CC=clang-5.0
+            export CXX=clang++-5.0
             bazel build //:dd_opentracing_cpp
       - run:
           name: Build opentracing-nginx


### PR DESCRIPTION
Related to #61, the error was not detected in regular build / test cycles because GCC compilers were used for those.
Some jobs deep within a different project use clang compilers for tsan / asan test runs, and would fail with a compilation error.
This makes sure we catch them.
Note: red build, will need rebasing after merging #61 and Datadog/docker-library#17, and pushing a new build image.