### PR TITLE
Debug symbols in Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ jobs:
   build:
     <<: *defaults
     environment:
-      CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_SHARED=OFF
-      NGINX_OPENTRACING_VERSION: 0.7.0
-      NGINX_VERSION: 1.14.0
+      CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
     steps:
       - checkout
       - run:
@@ -46,25 +44,6 @@ jobs:
             export CC=clang-6.0
             export CXX=clang++-6.0
             bazel build //:dd_opentracing_cpp
-      - run:
-          name: Build opentracing-nginx
-          command: |
-            wget https://github.com/opentracing-contrib/nginx-opentracing/archive/v${NGINX_OPENTRACING_VERSION}.tar.gz -O nginx-opentracing.tar.gz
-            mkdir nginx-opentracing
-            tar zxvf nginx-opentracing.tar.gz -C nginx-opentracing --strip-components=1
-
-            wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz -O nginx-${NGINX_VERSION}.tar.gz
-            tar zxvf nginx-${NGINX_VERSION}.tar.gz
-            # TODO(willgittoes-dd): Get these configure args automatically by installing nginx and using `nginx -V`.
-            cd nginx-${NGINX_VERSION}
-            ./configure \
-              --prefix=/etc/nginx --modules-path=/usr/lib/nginx/modules \
-              --user=nginx --group=nginx --with-compat --with-file-aio --with-threads \
-              --with-cc-opt="-g -O2 -fdebug-prefix-map=/data/builder/debuild/nginx-${NGINX_VERSION}/debian/debuild-base/nginx-${NGINX_VERSION}=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fPIC" \
-              --with-ld-opt='-Wl,-Bsymbolic-functions -specs=/usr/share/dpkg/no-pie-link.specs -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -pie' \
-              --add-dynamic-module=../nginx-opentracing/opentracing
-            make modules
-            cp objs/ngx_http_opentracing_module.so /tmp/build/ngx_http_opentracing_module.so
       - persist_to_workspace:
           root: /tmp/
           paths:
@@ -108,6 +87,7 @@ jobs:
       - image: datadog/docker-library:dd_opentracing_cpp_test_0_3_0
     environment:
       NGINX_VERSION: 1.14.0
+      NGINX_OPENTRACING_VERSION: 0.7.0
     steps:
       - checkout
       - attach_workspace:
@@ -128,7 +108,9 @@ jobs:
             # Install the Datadog plugin
             NGINX_MODULES=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p')
             cp ./build/libdd_opentracing_plugin.so /usr/local/lib/libdd_opentracing_plugin.so
-            cp ./build/ngx_http_opentracing_module.so ${NGINX_MODULES}/ngx_http_opentracing_module.so
+            # Install the nginx-opentracing plugin
+            wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v${NGINX_OPENTRACING_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz
+            tar zxf linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz -C "${NGINX_MODULES}"
             # Change the config to use it.
             cd ./test/integration/nginx/
             NGINX_CONF=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p')

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Each of these can be downloaded and used precompiled.
 
 ```bash
 # Install OpenTracing nginx module
-wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.6.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz
+wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.7.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz
 tar zxf linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Install Datadog OpenTracing
-wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/v0.3.1/linux-amd64-libdd_opentracing_plugin.so.gz
+wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/v0.3.3/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
 ```
 
@@ -109,7 +109,13 @@ Annotated Datadog config JSON:
   "agent_host": "localhost",
   "agent_port": 8126,
   // Client-side sampling. Discards (without counting) some number of traces where 1.0 means "keep all traces" and 0.0 means "keep no traces". Useful for improving performance in the case where nginx receives a large number of very small requests. Default value is 1.0 / keep everything.
-  "sample_rate": 1.0
+  "sample_rate": 1.0,
+  // A list of strings, each string is one of "Datadog", "B3". Defaults to ["Datadog", "B3"]. The type of headers
+  // to use to propagate distributed traces.
+  "propagation_style_extract": ["Datadog", "B3"],
+  // A list of strings, each string is one of "Datadog", "B3". Defaults to ["Datadog"]. The type of headers to use
+  // to receive distributed traces. 
+  "propagation_style_inject": ["Datadog"]
 }
 ```
 

--- a/examples/nginx-tracing/Dockerfile
+++ b/examples/nginx-tracing/Dockerfile
@@ -3,18 +3,18 @@ FROM ubuntu:18.04
 
 ARG NGINX_VERSION=1.14.0
 ARG NGINX_OPENTRACING_VERSION=0.7.0
-ARG DATADOG_PLUGIN_VERSION=0.3.1
+ARG DATADOG_PLUGIN_VERSION=0.3.3
 
 RUN apt-get update && \
-    apt-get install -y git gnupg wget tar
+  apt-get install -y git gnupg wget tar
 
 # Install nginx
 RUN wget https://nginx.org/keys/nginx_signing.key && \
-    apt-key add nginx_signing.key && \
-    echo deb https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
-    echo deb-src https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install nginx=${NGINX_VERSION}-1~bionic
+  apt-key add nginx_signing.key && \
+  echo deb https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
+  echo deb-src https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get install nginx=${NGINX_VERSION}-1~bionic
 # Configure nginx.
 COPY ./examples/nginx-tracing/nginx.conf /etc/nginx/nginx.conf
 COPY ./examples/nginx-tracing/dd-config.json /etc/dd-config.json

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -1,9 +1,5 @@
 FROM ubuntu:18.04 as build
 
-# Also set in the second stage.
-ARG NGINX_VERSION=1.14.0
-ARG NGINX_OPENTRACING_VERSION=0.6.0
-
 # Creates an image with nginx and the Datadog OpenTracing nginx module installed.
 # Runs a simple integration test.
 
@@ -26,26 +22,11 @@ RUN cmake -DBUILD_PLUGIN=ON -DBUILD_TESTING=OFF -DBUILD_SHARED=OFF ..
 RUN make
 RUN make install
 
-# Build nginx-opentracing ourselves
-RUN wget https://github.com/opentracing-contrib/nginx-opentracing/archive/v${NGINX_OPENTRACING_VERSION}.tar.gz -O nginx-opentracing.tar.gz && \
-  mkdir nginx-opentracing && \
-  tar zxvf nginx-opentracing.tar.gz -C nginx-opentracing --strip-components=1
-RUN wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz -O nginx-${NGINX_VERSION}.tar.gz
-RUN tar zxvf nginx-${NGINX_VERSION}.tar.gz
-# TODO(willgittoes-dd): Get these configure args automatically by installing nginx and using `nginx -V`.
-RUN cd nginx-${NGINX_VERSION} && \
-  ./configure \
-  --prefix=/etc/nginx --modules-path=/usr/lib/nginx/modules \
-  --user=nginx --group=nginx --with-compat --with-file-aio --with-threads \
-  --with-cc-opt="-g -O2 -fdebug-prefix-map=/data/builder/debuild/nginx-${NGINX_VERSION}/debian/debuild-base/nginx-${NGINX_VERSION}=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fPIC" \
-  --with-ld-opt='-Wl,-Bsymbolic-functions -specs=/usr/share/dpkg/no-pie-link.specs -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -pie' \
-  --add-dynamic-module=../nginx-opentracing/opentracing  && \
-  make  && \
-  make install
 
 FROM ubuntu:18.04
 
 ARG NGINX_VERSION=1.14.0
+ARG NGINX_OPENTRACING_VERSION=0.7.0
 
 RUN apt-get update && \
   apt-get install -y git gnupg lsb-release wget curl tar openjdk-8-jre golang jq
@@ -60,7 +41,8 @@ RUN CODENAME=$(lsb_release -s -c) && \
   apt-get install nginx=${NGINX_VERSION}-1~${CODENAME}
 
 # Install OpenTracing
-COPY --from=build /usr/lib/nginx/modules/ngx_http_opentracing_module.so /usr/lib/nginx/modules/ngx_http_opentracing_module.so
+RUN wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v${NGINX_OPENTRACING_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -O nginx-opentracing.tar.gz && \
+  tar zxvf nginx-opentracing.tar.gz -C /etc/nginx/modules/
 # And Datadog OT
 COPY --from=build /usr/local/lib/libdd_opentracing_plugin.so /usr/local/lib/libdd_opentracing_plugin.so
 


### PR DESCRIPTION
There's no real reason not to use RelWithDebInfo, if someone needs a very slightly smaller binary we can create a second build, but I think it's unlikely for now.

Also, CI changes. For the OpenTracing 1.5 upgrade, we had to switch to building Nginx-OT ourselves to break a circular dependency. I'm adding that back in, now that the upgrade is done, so that we can continue to test against the real releases of Nginx-OT, more accurately testing what our customers will be using.

Also updated some docs.