### PR TITLE
Sampling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Annotated Datadog config JSON:
   "agent_port": 8126,
   // Client-side sampling. Discards (without counting) some number of traces where 1.0 means "keep all traces" and 0.0 means "keep no traces". Useful for improving performance in the case where nginx receives a large number of very small requests. Default value is 1.0 / keep everything.
   "sample_rate": 1.0,
+  // Priority sampling. A boolean, true by default. If true disables client-side sampling (thus ignoring sample_rate)
+  // and enables distributed priority sampling, where traces are sampled based on a combination of user-assigned
+  // priorities and configuration from the agent.
+  "dd.priority.sampling": true,
   // A list of strings, each string is one of "Datadog", "B3". Defaults to ["Datadog", "B3"]. The type of headers
   // to use to propagate distributed traces.
   "propagation_style_extract": ["Datadog", "B3"],

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -42,7 +42,7 @@ struct TracerOptions {
   // If true, disables client-side sampling (thus ignoring sample_rate) and enables distributed
   // priority sampling, where traces are sampled based on a combination of user-assigned priorities
   // and configuration from the agent.
-  bool priority_sampling = false;
+  bool priority_sampling = true;
   // Max amount of time to wait between sending traces to agent, in ms. Agent discards traces older
   // than 10s, so that is the upper bound.
   int64_t write_period_ms = 1000;

--- a/src/propagation.h
+++ b/src/propagation.h
@@ -74,10 +74,10 @@ class SpanContext : public ot::SpanContext {
 
   uint64_t id() const;
   uint64_t traceId() const;
-  // Returns a pair of:
-  // * bool, true if this SpanContext may have arrived via propagation.
-  // * an OptionalSamplingPriority, the propagated sampling priority.
-  std::pair<bool, OptionalSamplingPriority> getPropagationStatus() const;
+  // Returns an OptionalSamplingPriority, the propagated sampling priority. It may hold a value of
+  // nullptr, in which case either there has been no propagation or the up-stream tracer did not
+  // set a sampling priority.
+  OptionalSamplingPriority getPropagatedSamplingPriority() const;
 
  private:
   static ot::expected<std::unique_ptr<ot::SpanContext>> deserialize(
@@ -105,7 +105,6 @@ class SpanContext : public ot::SpanContext {
   bool nginx_opentracing_compatibility_hack_ = false;
 
   OptionalSamplingPriority propagated_sampling_priority_ = nullptr;
-  bool has_propagated_ = false;
 
   uint64_t id_;
   uint64_t trace_id_;

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -34,9 +34,9 @@ void WritingSpanBuffer::registerSpan(const SpanContext& context) {
   if (trace == traces_.end()) {
     traces_.emplace(std::make_pair(trace_id, PendingTrace{}));
     trace = traces_.find(trace_id);
-    auto propagation_status = context.getPropagationStatus();
-    trace->second.sampling_priority_locked = propagation_status.first;
-    trace->second.sampling_priority = std::move(propagation_status.second);
+    OptionalSamplingPriority p = context.getPropagatedSamplingPriority();
+    trace->second.sampling_priority_locked = p != nullptr;
+    trace->second.sampling_priority = std::move(p);
   }
   trace->second.all_spans.insert(context.id());
 }

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -18,9 +18,15 @@ void PendingTrace::finish() {
   }
   // Check for sampling.
   if (sampling_priority != nullptr) {
-    // Set the metric for every span in the trace.
+    // Set the metric for the root span.
     for (auto& span : *finished_spans) {
-      span->metrics[sampling_priority_metric] = static_cast<int>(*sampling_priority);
+      if (/* root span */
+          span->parent_id == 0 ||
+          /* local root span of a distributed trace */
+          all_spans.find(span->parent_id) == all_spans.end()) {
+        span->metrics[sampling_priority_metric] = static_cast<int>(*sampling_priority);
+        break;
+      }
     }
   }
 }

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -37,7 +37,7 @@ ot::expected<std::set<PropagationStyle>> asPropagationStyle(json styles) {
 // "environment": A string, defaults to "". The environment this trace belongs to.
 //     eg. "" (env:none), "staging", "prod"
 // "sample_rate": A double, defaults to 1.0.
-// "dd.priority.sampling": A boolean, false by default. If true disables client-side sampling (thus
+// "dd.priority.sampling": A boolean, true by default. If true disables client-side sampling (thus
 //     ignoring sample_rate) and enables distributed priority sampling, where traces are sampled
 //     based on a combination of user-assigned priorities and configuration from the agent.
 // "operation_name_override": A string, if not empty it overrides the operation name (and the

--- a/test/integration/nginx/dd-config.json
+++ b/test/integration/nginx/dd-config.json
@@ -2,5 +2,6 @@
   "service": "nginx",
   "operation_name_override": "nginx.handle",
   "agent_host": "localhost",
-  "agent_port": 8126
+  "agent_port": 8126,
+  "dd.priority.sampling": false
 }

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -41,9 +41,9 @@ TEST_CASE("SpanContext") {
       REQUIRE(received_context);
       REQUIRE(received_context->id() == 420);
       REQUIRE(received_context->traceId() == 123);
-      auto status = received_context->getPropagationStatus();
-      REQUIRE(status.first == true);
-      REQUIRE(*status.second == SamplingPriority::SamplerKeep);
+      auto priority = received_context->getPropagatedSamplingPriority();
+      REQUIRE(priority != nullptr);
+      REQUIRE(*priority == SamplingPriority::SamplerKeep);
       REQUIRE(getBaggage(received_context) == dict{{"ayy", "lmao"}, {"hi", "haha"}});
 
       SECTION("even with extra keys") {
@@ -153,9 +153,9 @@ TEST_CASE("SamplingPriority values are clamped apropriately for b3") {
   REQUIRE(received_context);
   REQUIRE(received_context->id() == 420);
   REQUIRE(received_context->traceId() == 123);
-  auto status = received_context->getPropagationStatus();
-  REQUIRE(status.first == true);
-  REQUIRE(*status.second == priority.second);
+  auto received_priority = received_context->getPropagatedSamplingPriority();
+  REQUIRE(received_priority != nullptr);
+  REQUIRE(*received_priority == priority.second);
 }
 
 TEST_CASE("deserialize fails when there are conflicting b3 and datadog headers") {
@@ -200,9 +200,9 @@ TEST_CASE("Binary Span Context") {
       REQUIRE(received_context);
       REQUIRE(received_context->id() == 420);
       REQUIRE(received_context->traceId() == 123);
-      auto status = received_context->getPropagationStatus();
-      REQUIRE(status.first == true);
-      REQUIRE(*status.second == SamplingPriority::SamplerKeep);
+      auto priority = received_context->getPropagatedSamplingPriority();
+      REQUIRE(priority != nullptr);
+      REQUIRE(*priority == SamplingPriority::SamplerKeep);
       REQUIRE(getBaggage(received_context) == dict{{"ayy", "lmao"}, {"hi", "haha"}});
     }
   }

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -1,6 +1,7 @@
 #include "../src/propagation.h"
 #include <opentracing/tracer.h>
 #include <string>
+#include "../src/span.h"
 #include "../src/tracer.h"
 #include "mocks.h"
 
@@ -358,8 +359,8 @@ TEST_CASE("sampling behaviour") {
     span->Finish();
 
     auto& trace = writer->traces[0];
-    REQUIRE(trace[0]->metrics["_sampling_priority_v1"] ==
-            static_cast<int>(SamplingPriority::UserKeep));
+    // Child doesn't have metric set.
+    REQUIRE(trace[0]->metrics.find("_sampling_priority_v1") == trace[0]->metrics.end());
     REQUIRE(trace[1]->metrics["_sampling_priority_v1"] ==
             static_cast<int>(SamplingPriority::UserKeep));
   }
@@ -375,8 +376,7 @@ TEST_CASE("sampling behaviour") {
     span->Finish();
 
     auto& trace = writer->traces[0];
-    REQUIRE(trace[0]->metrics["_sampling_priority_v1"] ==
-            static_cast<int>(SamplingPriority::SamplerKeep));
+    REQUIRE(trace[0]->metrics.find("_sampling_priority_v1") == trace[0]->metrics.end());
     REQUIRE(trace[1]->metrics["_sampling_priority_v1"] ==
             static_cast<int>(SamplingPriority::SamplerKeep));
   }
@@ -398,8 +398,7 @@ TEST_CASE("sampling behaviour") {
     span->Finish();
 
     auto& trace = writer->traces[0];
-    REQUIRE(trace[0]->metrics["_sampling_priority_v1"] ==
-            static_cast<int>(SamplingPriority::UserKeep));
+    REQUIRE(trace[0]->metrics.find("_sampling_priority_v1") == trace[0]->metrics.end());
     REQUIRE(trace[1]->metrics["_sampling_priority_v1"] ==
             static_cast<int>(SamplingPriority::UserKeep));
   }
@@ -452,8 +451,7 @@ TEST_CASE("sampling behaviour") {
     span->Finish();
 
     auto& trace = writer->traces[0];
-    REQUIRE(trace[0]->metrics["_sampling_priority_v1"] ==
-            static_cast<int>(SamplingPriority::SamplerKeep));
+    REQUIRE(trace[0]->metrics.find("_sampling_priority_v1") == trace[0]->metrics.end());
     REQUIRE(trace[1]->metrics["_sampling_priority_v1"] ==
             static_cast<int>(SamplingPriority::SamplerKeep));
   }

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -160,6 +160,7 @@ TEST_CASE("correct sampler is used") {
 
   SECTION("rate sampler") {
     tracer_options.sample_rate = 0.4;
+    tracer_options.priority_sampling = false;
     auto sampler = sampleProviderFromOptions(tracer_options);
     REQUIRE(std::dynamic_pointer_cast<DiscardRateSampler>(sampler));
   }

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -321,7 +321,9 @@ TEST_CASE("span") {
               std::unordered_map<std::string, int>{{"_sampling_priority_v1", 1}});
     }
 
-    SECTION("non-root spans may not be sampled if they are distributed") {
+    SECTION(
+        "with priority sampling enabled enabled, propagated spans without a sampling priority "
+        "will be sampled even though they're not the root") {
       // parent_id is decoded to span_id, and the tracer will create a child context with the
       // span_id set to the span it's for. In this case we're deserializing (so as to simulate
       // propagation) but directly passing to the Span; so we encode parent_id as the id of the
@@ -341,7 +343,8 @@ TEST_CASE("span") {
       span.FinishWithOptions(finish_options);
 
       auto& result = buffer->traces(42).finished_spans->at(0);
-      REQUIRE(result->metrics == std::unordered_map<std::string, int>{});
+      REQUIRE(result->metrics ==
+              std::unordered_map<std::string, int>{{"_sampling_priority_v1", 1}});
     }
 
     SECTION("spans with an existing sampling priority may not be given a new one at Finish") {

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -320,8 +320,8 @@ TEST_CASE("span") {
     }
 
     SECTION(
-        "with priority sampling enabled enabled, propagated spans without a sampling priority "
-        "will be sampled even though they're not the root") {
+        "with priority sampling enabled, propagated spans without a sampling priority will be "
+        "sampled even though they're not the root") {
       // parent_id is decoded to span_id, and the tracer will create a child context with the
       // span_id set to the span it's for. In this case we're deserializing (so as to simulate
       // propagation) but directly passing to the Span; so we encode parent_id as the id of the

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -316,9 +316,7 @@ TEST_CASE("span") {
           "",         ""};
       span.FinishWithOptions(finish_options);
 
-      auto& result = buffer->traces(42).finished_spans->at(0);
-      REQUIRE(result->metrics ==
-              std::unordered_map<std::string, int>{{"_sampling_priority_v1", 1}});
+      REQUIRE(*buffer->traces(42).sampling_priority == SamplingPriority::SamplerKeep);
     }
 
     SECTION(


### PR DESCRIPTION
When writing up the RFC for Sampling Priority, I noticed a few cases where we weren't in-line with the spec. This fixes them:

- Priority sampling should be on by default (spec change)
- When receiving a propagated trace without an existing sampling priority, assign one
- Don't set metrics field unless it's the root span
