### PR TITLE
Apply options.tags when creating spans.

### DIFF
--- a/src/noopspan.cpp
+++ b/src/noopspan.cpp
@@ -7,8 +7,7 @@ namespace datadog {
 namespace opentracing {
 
 NoopSpan::NoopSpan(std::shared_ptr<const Tracer> tracer, uint64_t span_id, uint64_t trace_id,
-                   uint64_t parent_id, SpanContext context,
-                   const ot::StartSpanOptions & /* options */)
+                   uint64_t parent_id, SpanContext context)
     : tracer_(std::move(tracer)),
       span_id_(span_id),
       trace_id_(trace_id),

--- a/src/noopspan.h
+++ b/src/noopspan.h
@@ -19,7 +19,7 @@ class NoopSpan : public DatadogSpan {
  public:
   // Creates a new NoopSpan, usually called by Tracer::StartSpanWithOptions.
   NoopSpan(std::shared_ptr<const Tracer> tracer, uint64_t span_id, uint64_t trace_id,
-           uint64_t parent_id, SpanContext context, const ot::StartSpanOptions &options);
+           uint64_t parent_id, SpanContext context);
   NoopSpan() = delete;
   NoopSpan(NoopSpan &&other);
   ~NoopSpan() override = default;


### PR DESCRIPTION
This makes the tracer implementation set tags when `StartSpanWithOptions` is called.

A special case is required for the `opentracing::ext::sampling_priority` tag, because it may have been assigned already from the propagated context, and can't be changed after that assignment.

This fixes an issue with envoy, which traces all requests.
It has config options to trace a specific percentage of requests, and when it decides not to sample a trace, it passes the `opentracing::ext::sampling_priority` tag in, with the value `0`.
This change makes sure that tag is respected and applied to the span.