### PR TITLE
Make operation_name_override only apply to span name

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -126,7 +126,6 @@ void Span::FinishWithOptions(
   if (operation_name_override_ != "") {
     span_->meta[operation_name_tag] = span_->name;
     span_->name = operation_name_override_;
-    span_->resource = operation_name_override_;
   }
   // Apply special tags.
   // If we add any more cases; then abstract this. For now, KISS.

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -255,7 +255,7 @@ TEST_CASE("span") {
     REQUIRE(result->meta ==
             std::unordered_map<std::string, std::string>{{"operation", "original span name"}});
     REQUIRE(result->name == "overridden operation name");
-    REQUIRE(result->resource == "overridden operation name");
+    REQUIRE(result->resource == "original resource");
     REQUIRE(result->service == "original service");
     REQUIRE(result->type == "original type");
   }


### PR DESCRIPTION
When a span is finalized, the operation_name_override would replace the values of both `name` and `resource` with the override value.
It renders better in the trace list and flame chart if only the name is replaced with the override value, instead of showing the same value in both name and resource parts of the span.