### PR TITLE
remove redundant move

### DIFF
--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
   if (is_trace_root && opts_.environment != "") {
     span->SetTag(tags::environment, opts_.environment);
   }
-  return std::move(span);
+  return span;
 } catch (const std::bad_alloc &) {
   // At least don't crash.
   return nullptr;


### PR DESCRIPTION
gcc 9 reports this move as redundant:
```
[yuval@localhost envoy]$ gcc --version
gcc (GCC) 9.0.1 20190312 (Red Hat 9.0.1-0.10)
```
Gives this:
```
external/com_github_datadog_dd_opentracing_cpp/src/tracer.cpp: In member function 'virtual std::unique_ptr<opentracing::v2::Span> datadog::opentracing::Tracer::StartSpanWithOptions(opentra
cing::v2::string_view, const opentracing::v2::StartSpanOptions&) const':
external/com_github_datadog_dd_opentracing_cpp/src/tracer.cpp:101:19: error: redundant move in return statement [-Werror=redundant-move]
  101 |   return std::move(span);
      |          ~~~~~~~~~^~~~~~
```