### PR TITLE
Remove redundant move() call.

### DIFF
--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
   if (is_trace_root && opts_.environment != "") {
     span->SetTag(environment_tag, opts_.environment);
   }
-  return std::move(span);
+  return span;
 } catch (const std::bad_alloc &) {
   // At least don't crash.
   return nullptr;


### PR DESCRIPTION
I'm seeing the following Envoy build error with GCC 9.0.1:

    external/com_github_datadog_dd_opentracing_cpp/src/tracer.cpp: In member function 'virtual std::unique_ptr<opentracing::v2::Span> datadog::opentracing::Tracer::StartSpanWithOptions(opentracing::v2::string_view, const opentracing::v2::StartSpanOptions&) const':
    external/com_github_datadog_dd_opentracing_cpp/src/tracer.cpp:101:19: error: redundant move in return statement [-Werror=redundant-move]
      101 |   return std::move(span);
          |          ~~~~~~~~~^~~~~~
    external/com_github_datadog_dd_opentracing_cpp/src/tracer.cpp:101:19: note: remove 'std::move' call

I didn't test this change but it looks like the `move()` call is indeed not needed, since the function return type is the same as the pointer type, meaning the implicit move should work.