### PR TITLE
Add DD_TRACE_REPORT_HOSTNAME functionality

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -176,10 +176,6 @@ void Span::FinishWithOptions(
 
     span_->meta.erase(tag);
   }
-  // Report hostname if enabled and value was found.
-  if (!hostname_.empty()) {
-    span_->meta[datadog_hostname_tag] = std::string(hostname_);
-  }
   // Audit and finish span.
   audit(span_.get());
   buffer_->finishSpan(std::move(span_), sampler_);

--- a/src/span.h
+++ b/src/span.h
@@ -94,7 +94,7 @@ class Span : public DatadogSpan {
        TimeProvider get_time, std::shared_ptr<SampleProvider> sampler, uint64_t span_id,
        uint64_t trace_id, uint64_t parent_id, SpanContext context, TimePoint start_time,
        std::string span_service, std::string span_type, std::string span_name,
-       std::string resource, std::string operation_name_override);
+       std::string resource, std::string operation_name_override, const std::string hostname);
 
   Span() = delete;
   ~Span() override;
@@ -137,6 +137,7 @@ class Span : public DatadogSpan {
   SpanContext context_;
   TimePoint start_time_;
   std::string operation_name_override_;
+  const std::string hostname_;
 
   // Set in constructor initializer, depends on previous constructor initializer-set members:
   std::unique_ptr<SpanData> span_;

--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -27,6 +27,7 @@ struct PendingTrace {
   OptionalSamplingPriority sampling_priority;
   bool sampling_priority_locked = false;
   std::string origin;
+  std::string hostname;
 };
 
 // Keeps track of Spans until there is a complete trace.
@@ -45,10 +46,14 @@ class SpanBuffer {
   virtual void flush(std::chrono::milliseconds timeout) = 0;
 };
 
+struct WritingSpanBufferOptions {
+  std::string hostname;
+};
+
 // A SpanBuffer that sends completed traces to a Writer.
 class WritingSpanBuffer : public SpanBuffer {
  public:
-  WritingSpanBuffer(std::shared_ptr<Writer> writer);
+  WritingSpanBuffer(std::shared_ptr<Writer> writer, WritingSpanBufferOptions options);
 
   void registerSpan(const SpanContext& context) override;
   void finishSpan(std::unique_ptr<SpanData> span,
@@ -80,6 +85,7 @@ class WritingSpanBuffer : public SpanBuffer {
   virtual void unbufferAndWriteTrace(uint64_t trace_id);
 
   std::unordered_map<uint64_t, PendingTrace> traces_;
+  WritingSpanBufferOptions options_;
 };
 
 }  // namespace opentracing

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -2,6 +2,7 @@
 #include <datadog/tags.h>
 #include <opentracing/ext/tags.h>
 #include <pthread.h>
+#include <unistd.h>
 #include <cstdlib>
 #include <random>
 
@@ -41,17 +42,36 @@ uint64_t getId() {
   return distribution(TlsRandomNumberGenerator::generator());
 }
 
+std::string reportingHostname() {
+  // This returns the machine name if the DD_TRACE_REPORT_HOSTNAME is set to true.
+  auto report_hostname_opt = std::getenv("DD_TRACE_REPORT_HOSTNAME");
+  if (report_hostname_opt != nullptr && std::strlen(report_hostname_opt) > 0) {
+    if (std::string(report_hostname_opt) == "true") {
+      char buffer[256];
+      if (!::gethostname(buffer, 256)) {
+        return std::string(buffer);
+      }
+    }
+  }
+  return "";
+}
+
 Tracer::Tracer(TracerOptions options, std::shared_ptr<SpanBuffer> buffer, TimeProvider get_time,
                IdProvider get_id, std::shared_ptr<SampleProvider> sampler)
     : opts_(options),
       buffer_(std::move(buffer)),
       get_time_(get_time),
       get_id_(get_id),
-      sampler_(sampler) {}
+      sampler_(sampler),
+      hostname_(reportingHostname()) {}
 
 Tracer::Tracer(TracerOptions options, std::shared_ptr<Writer> &writer,
                std::shared_ptr<SampleProvider> sampler)
-    : opts_(options), get_time_(getRealTime), get_id_(getId), sampler_(sampler) {
+    : opts_(options),
+      get_time_(getRealTime),
+      get_id_(getId),
+      sampler_(sampler),
+      hostname_(reportingHostname()) {
   buffer_ = std::shared_ptr<SpanBuffer>{new WritingSpanBuffer{writer}};
 }
 
@@ -88,7 +108,7 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
   std::unique_ptr<Span> span{new Span{shared_from_this(), buffer_, get_time_, sampler_, span_id,
                                       trace_id, parent_id, std::move(span_context), get_time_(),
                                       opts_.service, opts_.type, operation_name, operation_name,
-                                      opts_.operation_name_override}};
+                                      opts_.operation_name_override, hostname_}};
   bool is_trace_root = parent_id == 0;
   for (auto &tag : options.tags) {
     if (tag.first == ::ot::ext::sampling_priority && span->getSamplingPriority() != nullptr) {

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -72,7 +72,8 @@ Tracer::Tracer(TracerOptions options, std::shared_ptr<Writer> &writer,
       get_id_(getId),
       sampler_(sampler),
       hostname_(reportingHostname()) {
-  buffer_ = std::shared_ptr<SpanBuffer>{new WritingSpanBuffer{writer}};
+  buffer_ = std::shared_ptr<SpanBuffer>{
+      new WritingSpanBuffer{writer, WritingSpanBufferOptions{reportingHostname()}}};
 }
 
 std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation_name,

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -72,6 +72,7 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   TimeProvider get_time_;
   IdProvider get_id_;
   std::shared_ptr<SampleProvider> sampler_;
+  const std::string hostname_;
 };
 
 }  // namespace opentracing

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -74,7 +74,8 @@ struct MockWriter : public Writer {
 
 struct MockBuffer : public WritingSpanBuffer {
   MockBuffer()
-      : WritingSpanBuffer(std::make_shared<MockWriter>(std::make_shared<MockSampler>())){};
+      : WritingSpanBuffer(std::make_shared<MockWriter>(std::make_shared<MockSampler>()),
+                          WritingSpanBufferOptions{}){};
 
   void unbufferAndWriteTrace(uint64_t /* trace_id */) override{
       // Haha NOPE.
@@ -84,6 +85,8 @@ struct MockBuffer : public WritingSpanBuffer {
   std::unordered_map<uint64_t, PendingTrace>& traces() { return traces_; };
 
   PendingTrace& traces(uint64_t id) { return traces_[id]; };
+
+  void setHostname(std::string hostname) { options_.hostname = hostname; };
 
   void flush(std::chrono::milliseconds /* timeout (unused) */) override{};
 };

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -305,7 +305,7 @@ TEST_CASE("Binary Span Context") {
 TEST_CASE("sampling behaviour") {
   auto sampler = std::make_shared<MockSampler>();
   auto writer = std::make_shared<MockWriter>(sampler);
-  auto buffer = std::make_shared<WritingSpanBuffer>(writer);
+  auto buffer = std::make_shared<WritingSpanBuffer>(writer, WritingSpanBufferOptions{});
   TracerOptions tracer_options{"", 0, "service_name", "web"};
   std::shared_ptr<Tracer> tracer{new Tracer{tracer_options, buffer, getRealTime, getId, sampler}};
   ot::Tracer::InitGlobal(tracer);
@@ -513,7 +513,7 @@ TEST_CASE("sampling behaviour") {
 TEST_CASE("force tracing behaviour") {
   auto sampler = std::make_shared<MockSampler>();
   auto writer = std::make_shared<MockWriter>(sampler);
-  auto buffer = std::make_shared<WritingSpanBuffer>(writer);
+  auto buffer = std::make_shared<WritingSpanBuffer>(writer, WritingSpanBufferOptions{});
   TracerOptions tracer_options{"", 0, "service_name", "web"};
   std::shared_ptr<Tracer> tracer{new Tracer{tracer_options, buffer, getRealTime, getId, sampler}};
   ot::Tracer::InitGlobal(tracer);

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -188,7 +188,7 @@ TEST_CASE("priority sampler \"integration\" test") {
   auto writer = std::make_shared<AgentWriter>(
       std::move(handle_ptr), only_send_traces_when_we_flush, 11000 /* max queued traces */,
       std::vector<std::chrono::milliseconds>{}, "hostname", 6319, sampler);
-  auto buffer = std::make_shared<WritingSpanBuffer>(writer);
+  auto buffer = std::make_shared<WritingSpanBuffer>(writer, WritingSpanBufferOptions{});
 
   std::shared_ptr<Tracer> tracer{new Tracer{tracer_options, buffer, getRealTime, getId, sampler}};
   const ot::StartSpanOptions span_options;

--- a/test/span_buffer_test.cpp
+++ b/test/span_buffer_test.cpp
@@ -10,7 +10,7 @@ TEST_CASE("span buffer") {
   auto sampler = std::make_shared<KeepAllSampler>();
   auto writer_ptr = std::make_shared<MockWriter>(sampler);
   MockWriter* writer = writer_ptr.get();
-  auto buffer = std::make_shared<WritingSpanBuffer>(writer_ptr);
+  auto buffer = std::make_shared<WritingSpanBuffer>(writer_ptr, WritingSpanBufferOptions{});
 
   auto context_from_span = [](const TestSpanData& span) -> SpanContext {
     return SpanContext{span.span_id, span.trace_id, "", {}};

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -456,28 +456,4 @@ TEST_CASE("span") {
               std::unordered_map<std::string, double>{{"_sampling_priority_v1", -1}});
     }
   }
-
-  SECTION("non-empty hostnames are reported via a tag") {
-    auto span_id = get_id();
-    Span span{nullptr,
-              buffer,
-              get_time,
-              sampler,
-              span_id,
-              span_id,
-              0,
-              SpanContext{span_id, span_id, "", {}},
-              get_time(),
-              "original service",
-              "original type",
-              "original span name",
-              "original resource",
-              "",
-              "myhostname"};
-
-    span.FinishWithOptions(finish_options);
-
-    auto& result = buffer->traces(100).finished_spans->at(0);
-    REQUIRE(result->meta["_dd.hostname"] == "myhostname");
-  }
 }


### PR DESCRIPTION
When `DD_TRACE_REPORT_HOSTNAME` is set to `true`, an additional tag is added to traces automatically, containing the hostname.