### PR TITLE
Add new header to BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
     ],
     hdrs = [
         "include/datadog/opentracing.h",
+        "include/datadog/tags.h",
     ],
     copts = [
         "-Wall",


### PR DESCRIPTION
Envoy uses this library via a bazel dependency.
Bazel needs to have all files listed in specific categories.
The new `tags.h` header wasn't added to the bazel spec, so it needs this change before it can be compiled with envoy.

The `WORKSPACE` may also be unnecessary for the "bazel dependency" use case, but it seems to be harmless for now, so it can wait for a future PR.