### PR TITLE
Replace ':' in span tag keys with '.'

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -300,15 +300,19 @@ struct VariantVisitor {
 };
 }  // namespace
 
-// Replaces some characters in span tag keys with a '.'
-// For now, only ':' is replaced.
-std::string replacePunctuation(std::string tag) {
+// Normalizes the tag key.
+// For now:
+// - ':' is replaced with '.'
+// Further normalization may be done in the future, such as
+// converting to lowercase, and replacing spaces and other punctuation
+// with underscore.
+std::string normalizeTagKey(std::string tag) {
   std::replace(tag.begin(), tag.end(), ':', '.');
   return tag;
 }
 
 void Span::SetTag(ot::string_view key, const ot::Value &value) noexcept {
-  std::string k = replacePunctuation(key);
+  std::string k = normalizeTagKey(key);
   std::string result;
   apply_visitor(VariantVisitor{result}, value);
   {

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -136,7 +136,7 @@ TEST_CASE("span") {
     span.SetTag("double", 6.283185);
     span.SetTag("int64_t", -69);
     span.SetTag("uint64_t", 420);
-    span.SetTag("std::string", std::string("hi there"));
+    span.SetTag("string", std::string("hi there"));
     span.SetTag("nullptr", nullptr);
     span.SetTag("char*", "hi there");
     span.SetTag("list", std::vector<ot::Value>{"hi", 420, true});
@@ -159,10 +159,27 @@ TEST_CASE("span") {
                                 {"double", "6.283185"},
                                 {"int64_t", "-69"},
                                 {"uint64_t", "420"},
-                                {"std::string", "hi there"},
+                                {"string", "hi there"},
                                 {"nullptr", "nullptr"},
                                 {"char*", "hi there"},
                                 {"list", "[\"hi\",420,true]"},
+                            });
+  }
+
+  SECTION("replaces colons with dots in tag key") {
+    auto span_id = get_id();
+    Span span{nullptr,    buffer,  get_time, sampler,
+              span_id,    span_id, 0,        SpanContext{span_id, span_id, "", {}},
+              get_time(), "",      "",       "",
+              "",         ""};
+
+    span.SetTag("foo:bar:baz", "x");
+
+    span.FinishWithOptions(finish_options);
+
+    auto& result = buffer->traces(100).finished_spans->at(0);
+    REQUIRE(result->meta == std::unordered_map<std::string, std::string>{
+                                {"foo.bar.baz", "x"},
                             });
   }
 


### PR DESCRIPTION
Envoy adds a tag `guid:x-request-id` to the trace spans. However, this value can't be used as a facet in trace analytics.
This PR replaces the `:` with `.` in tag names, which is acceptable for making a facet.