### PR TITLE
Ignore http status code with value 0.

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -303,6 +303,14 @@ struct VariantVisitor {
 void Span::SetTag(ot::string_view key, const ot::Value &value) noexcept {
   std::string result;
   apply_visitor(VariantVisitor{result}, value);
+
+  // Check for invalid values.
+  // - tag: http.status_code, value: "0"
+  if (key == ::ot::ext::http_status_code && result == "0") {
+    return;
+  }
+
+  // Store the tag and value in span metadata.
   {
     std::lock_guard<std::mutex> lock_guard{mutex_};
     span_->meta[key] = result;

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -372,6 +372,30 @@ TEST_CASE("span") {
     }
   }
 
+  SECTION("invalid http status code is ignored") {
+    auto span_id = get_id();
+    Span span{nullptr,
+              buffer,
+              get_time,
+              sampler,
+              span_id,
+              span_id,
+              0,
+              SpanContext{span_id, span_id, "", {}},
+              get_time(),
+              "original service",
+              "original type",
+              "original span name",
+              "original resource",
+              "overridden operation name"};
+
+    span.SetTag(ot::ext::http_status_code, 0);
+    span.FinishWithOptions(finish_options);
+
+    auto& result = buffer->traces(100).finished_spans->at(0);
+    REQUIRE(result->meta.find(ot::ext::http_status_code) == result->meta.end());
+  }
+
   SECTION("sampling") {
     auto priority_sampler = std::make_shared<MockSampler>();
     priority_sampler->sampling_priority =


### PR DESCRIPTION
Under some circumstances, envoy adds the `http.status_code` tag with a value that isn't permitted by Datadog.
Although invalid values are detected in newer versions of the agent, and corrected by removing that tag from the span, it's better if it doesn't occur at all.

This PR ignores the `http.status_code` tag if the value is `"0"`.