### PR TITLE
Changed how tests are built for faster compilation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,11 @@
+add_library(catch STATIC test_main.cpp)
+
 macro(_datadog_test TEST_NAME)
   add_executable(${TEST_NAME} ${ARGN})
   add_sanitizers(${TEST_NAME})  
   target_link_libraries(${TEST_NAME} ${DATADOG_LINK_LIBRARIES}
-                                     dd_opentracing)
+                                     dd_opentracing
+                                     catch)
   add_test(${TEST_NAME} ${TEST_NAME})
 endmacro()
 

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -5,7 +5,6 @@
 
 #include <ctime>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/opentracing_test.cpp
+++ b/test/opentracing_test.cpp
@@ -1,7 +1,6 @@
 #include <datadog/opentracing.h>
 #include "mocks.h"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -7,7 +7,6 @@
 #include "../src/tracer.h"
 #include "mocks.h"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 namespace tags = datadog::tags;

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -6,7 +6,6 @@
 
 #include <ctime>
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/span_buffer_test.cpp
+++ b/test/span_buffer_test.cpp
@@ -2,7 +2,6 @@
 #include "../src/sample.h"
 #include "mocks.h"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -7,7 +7,6 @@
 #include "../src/sample.h"
 #include "mocks.h"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 namespace tags = datadog::tags;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -4,7 +4,6 @@
 // Source file needed to ensure compilation of templated class TracerFactory<MockTracer>
 #include "../src/tracer_factory.cpp"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -1,6 +1,5 @@
 #include "../src/tracer_options.h"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -1,10 +1,10 @@
 #include "../src/tracer.h"
+#include <unistd.h>
 #include <ctime>
 #include "../src/sample.h"
 #include "../src/span.h"
 #include "mocks.h"
 
-#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 


### PR DESCRIPTION
This PR doesn't actually enhance the library performance, but compile time when building with `BUILD_TESTING=ON` is faster by around 50%.

I've measured compilation time with `time (cmake -DBUILD_TESTING=ON .. && make && ctest --output-on-failure)`.
Before:
`128,05s user 5,15s system 98% cpu 2:14,64 total`
After:
`72,01s user 3,73s system 98% cpu 1:17,00 total`

As recommended by Catch2 documentation on this [README](https://github.com/catchorg/Catch2/blob/master/docs/slow-compiles.md) it's better to build Catch2 `main` in a separate static library and link each test to it, this way Catch2 `main` is generated and built only once and changing a test doesn't require rebuilding it.