### PR TITLE
version bump for 1.1.1 and version check scripts enforced by CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
               fi
             done
       - run:
+          name: Check version info is up-to-date
+          command: ./test/version/version_check
+      - run:
           name: Build source dependencies
           command: |
             ./scripts/install_dependencies.sh

--- a/include/datadog/version.h
+++ b/include/datadog/version.h
@@ -6,7 +6,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.0.1";
+const std::string tracer_version = "v1.1.1";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version

--- a/test/version/current_version.cc
+++ b/test/version/current_version.cc
@@ -1,0 +1,8 @@
+#include <datadog/version.h>
+
+#include <iostream>
+
+int main() {
+  std::cout << datadog::version::tracer_version << std::endl;
+  return 0;
+}

--- a/test/version/version_check
+++ b/test/version/version_check
@@ -15,7 +15,7 @@ if ! type g++ > /dev/null; then
     exit 0
 fi
 
-if ! g++ -I$(git rev-parse --show-toplevel)/include -o current_version current_version.cc; then
+if ! g++ -I"$(git rev-parse --show-toplevel)"/include -o current_version current_version.cc; then
     echo "failed to compile current_version.cc"
     exit 1
 fi

--- a/test/version/version_check
+++ b/test/version/version_check
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if ! cd "${0%/*}"; then
+    echo "failed to change working directory"
+    exit 1
+fi
+
+if ! type git > /dev/null; then
+    echo "git not available."
+    exit 0
+fi
+
+if ! type g++ > /dev/null; then
+    echo "g++ not available."
+    exit 0
+fi
+
+if ! g++ -I$(git rev-parse --show-toplevel)/include -o current_version current_version.cc; then
+    echo "failed to compile current_version.cc"
+    exit 1
+fi
+if ! version=$(./current_version); then
+    echo "failed to execute current_version"
+    exit 1
+fi
+if ! [[ "$version" ]]; then
+    echo "empty version info"
+    exit 1
+fi
+rm ./current_version
+
+if ! git rev-parse "$version" &>/dev/null; then
+    # already updated
+    exit 0
+fi
+
+head_ts=$(git show -s --format=%ct HEAD)
+vers_ts=$(git show -s --format=%ct "$version")
+
+if ((head_ts > vers_ts)); then
+    echo "version tag is outdated and needs an update"
+    exit 1
+fi


### PR DESCRIPTION
The release of v1.1.0 would report traces with the incorrect, earlier version (v1.0.1).
This PR updates the version and makes sure the CI rejects PRs when the version has become outdated, eg: HEAD is newer than the version inside the header.
