### PR TITLE
Fix nginx example / sandbox

### DIFF
--- a/examples/nginx-tracing/Dockerfile
+++ b/examples/nginx-tracing/Dockerfile
@@ -1,7 +1,7 @@
 # Builds and runs a simple nginx server, traced by Datadog
 FROM ubuntu:18.04
 
-ARG NGINX_VERSION=1.14.0
+ARG NGINX_VERSION=1.14.2
 
 RUN apt-get update && \
   apt-get install -y git gnupg wget tar

--- a/examples/nginx-tracing/docker-compose.yml
+++ b/examples/nginx-tracing/docker-compose.yml
@@ -16,5 +16,3 @@ services:
       - DD_API_KEY
       - 'DD_APM_ENABLED=true'
     image: 'datadog/agent'
-    ports:
-        - "127.0.0.1:8126:8126"

--- a/include/datadog/version.h
+++ b/include/datadog/version.h
@@ -6,7 +6,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.1.1";
+const std::string tracer_version = "v1.1.2";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version


### PR DESCRIPTION
Small fixes to the nginx sandbox
- opentracing-nginx stopped providing builds for nginx 1.14.0, updated to 1.14.2
- removed port binding for `127.0.0.1:8126`: it's not needed