### PR TITLE
Generate int64 values instead of uint64

### DIFF
--- a/include/datadog/version.h
+++ b/include/datadog/version.h
@@ -6,7 +6,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.1.1";
+const std::string tracer_version = "v1.1.2";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -37,7 +37,7 @@ thread_local std::mt19937_64 TlsRandomNumberGenerator::random_number_generator_{
 
 uint64_t getId() {
   static TlsRandomNumberGenerator rng;
-  static thread_local std::uniform_int_distribution<uint64_t> distribution;
+  static thread_local std::uniform_int_distribution<int64_t> distribution;
   return distribution(TlsRandomNumberGenerator::generator());
 }
 


### PR DESCRIPTION
Some other tracer implementations don't yet support IDs larger than 2^63.
This makes sure the generated IDs are kept within the supported limits.

Also version bump.