### PR TITLE
Rate sampler not overriding distributed sampling decision

### DIFF
--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -126,7 +126,8 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
 
   // Check early if we need to discard. Check at span Finish if we need to sample (since users can
   // set this).
-  if (sampler_->discard(span_context)) {
+  if (span_context.getPropagatedSamplingPriority() == nullptr && sampler_->discard(span_context)) {
+    std::cout << "discarding " << span_context.traceId() << std::endl;
     return std::unique_ptr<ot::Span>{
         new NoopSpan{shared_from_this(), span_id, trace_id, parent_id, std::move(span_context)}};
   }

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -127,7 +127,6 @@ std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation
   // Check early if we need to discard. Check at span Finish if we need to sample (since users can
   // set this).
   if (span_context.getPropagatedSamplingPriority() == nullptr && sampler_->discard(span_context)) {
-    std::cout << "discarding " << span_context.traceId() << std::endl;
     return std::unique_ptr<ot::Span>{
         new NoopSpan{shared_from_this(), span_id, trace_id, parent_id, std::move(span_context)}};
   }


### PR DESCRIPTION
This came up as part of #117, and since there's some use of rate sampling, this is to make it "play nicely" with priority sampling.
Essentially: rate sampling is not applied to a distributed trace that already has a sampling decision.