### PR TITLE
Expose sampling decision to external tracers

### DIFF
--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -77,6 +77,8 @@ class TraceEncoder {
   virtual const std::string payload() = 0;
   // Receives and handles the response from the Agent.
   virtual void handleResponse(const std::string& response) = 0;
+  //
+  virtual bool sampled(const ot::SpanContext& ctx, bool) = 0;
 };
 
 // makeTracer returns an opentracing::Tracer that submits traces to the Datadog Agent.

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -77,5 +77,18 @@ void AgentHttpEncoder::handleResponse(const std::string& response) {
   }
 }
 
+bool AgentHttpEncoder::sampled(const ot::SpanContext& ctx, bool fallback_decision) try {
+  auto context = dynamic_cast<const SpanContext*>(&ctx);
+  if (context != nullptr) {
+    OptionalSamplingPriority p = context->getPropagatedSamplingPriority();
+    if (p != nullptr) {
+      return *p > SamplingPriority::SamplerDrop;
+    }
+  }
+  return fallback_decision;
+} catch (std::bad_cast&) {
+  return fallback_decision;
+}
+
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -29,7 +29,7 @@ class AgentHttpEncoder : public TraceEncoder {
   // Returns the encoded payload from the collection of traces.
   const std::string payload() override;
   void handleResponse(const std::string& response) override;
-  bool sampled(const ot::SpanContext& ctx, bool fallback_decision);
+  bool sampled(const ot::SpanContext& ctx, bool fallback_decision) override;
   void addTrace(Trace trace);
 
  private:

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -29,6 +29,7 @@ class AgentHttpEncoder : public TraceEncoder {
   // Returns the encoded payload from the collection of traces.
   const std::string payload() override;
   void handleResponse(const std::string& response) override;
+  bool sampled(const ot::SpanContext& ctx, bool fallback_decision);
   void addTrace(Trace trace);
 
  private:

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -234,3 +234,31 @@ TEST_CASE("priority sampler \"integration\" test") {
     REQUIRE((sample_rate < 0.35 && sample_rate > 0.25));
   }
 }
+
+TEST_CASE("trace encoder sampling decision") {
+  std::shared_ptr<SampleProvider> sampler = std::make_shared<PrioritySampler>();
+  std::unique_ptr<TraceEncoder> encoder = std::make_unique<AgentHttpEncoder>(sampler);
+
+  std::istringstream p1_ctx(R"({"trace_id": "100", "parent_id": "100", "sampling_priority": 1})");
+  opentracing::expected<std::unique_ptr<opentracing::SpanContext>> sampled =
+      SpanContext::deserialize(p1_ctx);
+  std::istringstream p0_ctx(R"({"trace_id": "100", "parent_id": "100", "sampling_priority": 0})");
+  opentracing::expected<std::unique_ptr<opentracing::SpanContext>> unsampled =
+      SpanContext::deserialize(p0_ctx);
+  std::istringstream no_priority_ctx(R"({"trace_id": "100", "parent_id": "100"})");
+  opentracing::expected<std::unique_ptr<opentracing::SpanContext>> undecided =
+      SpanContext::deserialize(no_priority_ctx);
+  REQUIRE(sampled);
+  REQUIRE(unsampled);
+  REQUIRE(undecided);
+
+  auto tracing_decision = GENERATE(false, true);
+  SECTION("prioritizes propagated sampling decision") {
+    auto result = encoder->sampled(*(sampled.value().get()), tracing_decision);
+    REQUIRE(result == true);
+    result = encoder->sampled(*(unsampled.value().get()), tracing_decision);
+    REQUIRE(result == false);
+    result = encoder->sampled(*(undecided.value().get()), tracing_decision);
+    REQUIRE(result == tracing_decision);
+  }
+}


### PR DESCRIPTION
This is part of a fix for envoyproxy/envoy#9076, so that tracers have a chance to be involved in sampling decisions. In a distributed trace, it's not great if middle-bits make their own sampling decisions.

So this exposes a method for envoy to call, and report back a tracer-based decision.
