### PR TITLE
Default to RelWithDebInfo for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ if(BUILD_TESTING)
 endif()
 
 # Configure the compiler.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
 set(CMAKE_CXX_STANDARD 14)
 
 # Includes


### PR DESCRIPTION
Not sure if this is necessary, but it's a nicer default to be using.