### PR TITLE
Exposes additional tracer options in config struct and JSON

### DIFF
--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -59,10 +59,10 @@ struct TracerOptions {
   // The style of propagation headers to emit/inject. Can also be set by the environment variable
   // DD_PROPAGATION_STYLE_INJECT.
   std::set<PropagationStyle> inject{PropagationStyle::Datadog};
-  // If true, injects the hostname into spans reported by this tracer. Can also be sert by the
+  // If true, injects the hostname into spans reported by this tracer. Can also be set by the
   // environment variable DD_TRACE_REPORT_HOSTNAME.
   bool report_hostname = false;
-  // If true and global analytics rate is not set, spans will be tagged witn an analytics rate
+  // If true and global analytics rate is not set, spans will be tagged with an analytics rate
   // of 1.0. Can also be set by the environment variable DD_TRACE_ANALYTICS_ENABLED.
   bool analytics_enabled = false;
   // When set to a value between 0.0 and 1.0 (inclusive), spans will be tagged with the provided

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -3,6 +3,7 @@
 
 #include <opentracing/tracer.h>
 
+#include <cmath>
 #include <map>
 #include <set>
 
@@ -58,6 +59,16 @@ struct TracerOptions {
   // The style of propagation headers to emit/inject. Can also be set by the environment variable
   // DD_PROPAGATION_STYLE_INJECT.
   std::set<PropagationStyle> inject{PropagationStyle::Datadog};
+  // If true, injects the hostname into spans reported by this tracer. Can also be sert by the
+  // environment variable DD_TRACE_REPORT_HOSTNAME.
+  bool report_hostname = false;
+  // If true and global analytics rate is not set, spans will be tagged witn an analytics rate
+  // of 1.0. Can also be set by the environment variable DD_TRACE_ANALYTICS_ENABLED.
+  bool analytics_enabled = false;
+  // When set to a value between 0.0 and 1.0 (inclusive), spans will be tagged with the provided
+  // value for analytics sampling rate. Can also be set by the environment variable
+  // DD_TRACE_ANALYTICS_SAMPLE_RATE
+  double analytics_rate = std::nan("");
 };
 
 // TraceEncoder exposes the data required to encode and submit traces to the

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -72,6 +72,15 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
       }
       options.inject = styles.value();
     }
+    if (config.find("dd.trace.report-hostname") != config.end()) {
+      config.at("dd.trace.report-hostname").get_to(options.report_hostname);
+    }
+    if (config.find("dd.trace.analytics-enabled") != config.end()) {
+      config.at("dd.trace.analytics-enabled").get_to(options.analytics_enabled);
+    }
+    if (config.find("dd.trace.analytics-sample-rate") != config.end()) {
+      config.at("dd.trace.analytics-sample-rate").get_to(options.analytics_rate);
+    }
   } catch (const nlohmann::detail::type_error &) {
     error_message = "configuration has an argument with an incorrect type";
     return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -55,6 +55,48 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
     opts.inject = style_maybe.value();
   }
 
+  auto report_hostname = std::getenv("DD_TRACE_REPORT_HOSTNAME");
+  if (report_hostname != nullptr) {
+    auto value = std::string(report_hostname);
+    if (value == "true" || value == "1") {
+      opts.report_hostname = true;
+    } else if (value == "false" || value == "0" || value == "") {
+      opts.report_hostname = false;
+    } else {
+      return ot::make_unexpected("Value for DD_TRACE_REPORT_HOSTNAME is invalid");
+    }
+  }
+
+  auto analytics_enabled = std::getenv("DD_TRACE_ANALYTICS_ENABLED");
+  if (analytics_enabled != nullptr) {
+    auto value = std::string(analytics_enabled);
+    if (value == "true" || value == "1") {
+      opts.analytics_enabled = true;
+      opts.analytics_rate = 1.0;
+    } else if (value == "false" || value == "0" || value == "") {
+      opts.analytics_enabled = false;
+      opts.analytics_rate = std::nan("");
+    } else {
+      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_ENABLED is invalid");
+    }
+  }
+
+  auto analytics_rate = std::getenv("DD_TRACE_ANALYTICS_SAMPLE_RATE");
+  if (analytics_rate != nullptr) {
+    try {
+      double value = std::stod(analytics_rate);
+      if (value >= 0.0 && value <= 1.0) {
+        opts.analytics_enabled = true;
+        opts.analytics_rate = value;
+      } else {
+        return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid");
+      }
+    } catch (const std::invalid_argument &ia) {
+      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid");
+    } catch (const std::out_of_range &oor) {
+      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid");
+    }
+  }
   return opts;
 }
 

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -1,8 +1,11 @@
 #include "../src/tracer_factory.h"
 #include "../src/tracer.h"
+#include "mocks.h"
 
 // Source file needed to ensure compilation of templated class TracerFactory<MockTracer>
 #include "../src/tracer_factory.cpp"
+
+#include <unistd.h>
 
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
@@ -77,8 +80,12 @@ TEST_CASE("tracer") {
              {"[\"Datadog\", \"B3\"]", {PropagationStyle::Datadog, PropagationStyle::B3}},
              {"[\"Datadog\", \"B3\", \"Datadog\", \"B3\"]",
               {PropagationStyle::Datadog, PropagationStyle::B3}}}));
+    auto report_hostname = GENERATE(false, true);
+    auto analytics_enabled = GENERATE(false, true);
+    auto analytics_rate = GENERATE(0.0, 0.5, 1.0);
 
     std::ostringstream input;
+    input << std::boolalpha;
     input << R"(
       {
         "service": "my-service",
@@ -88,7 +95,13 @@ TEST_CASE("tracer") {
         "propagation_style_extract": )"
           << propagation_style_extract.first << R"(,
         "propagation_style_inject": )"
-          << propagation_style_inject.first << R"(
+          << propagation_style_inject.first << R"(,
+        "dd.trace.report-hostname": )"
+          << report_hostname << R"(,
+        "dd.trace.analytics-enabled": )"
+          << analytics_enabled << R"(,
+        "dd.trace.analytics-sample-rate": )"
+          << analytics_rate << R"(
       }
     )";
     std::string error = "";
@@ -102,6 +115,9 @@ TEST_CASE("tracer") {
     REQUIRE(tracer->opts.type == "db");
     REQUIRE(tracer->opts.extract == propagation_style_extract.second);
     REQUIRE(tracer->opts.inject == propagation_style_inject.second);
+    REQUIRE(tracer->opts.report_hostname == report_hostname);
+    REQUIRE(tracer->opts.analytics_enabled == analytics_enabled);
+    REQUIRE(tracer->opts.analytics_rate == analytics_rate);
   }
 
   SECTION("can be created without optional fields") {
@@ -362,6 +378,74 @@ TEST_CASE("tracer") {
       REQUIRE(error == "Value for DD_TRACE_AGENT_PORT is invalid");
       REQUIRE(!result);
       REQUIRE(result.error() == std::make_error_code(std::errc::invalid_argument));
+    }
+    SECTION("DD_TRACE_REPORT_HOSTNAME overrides default") {
+      ::setenv("DD_TRACE_REPORT_HOSTNAME", "true", 0);
+      std::string input{R"(
+      {
+        "service": "my-service"
+      }
+      )"};
+      std::string error = "";
+      auto result = factory.MakeTracer(input.c_str(), error);
+      ::unsetenv("DD_TRACE_REPORT_HOSTNAME");
+
+      REQUIRE(error == "");
+      REQUIRE(result->get() != nullptr);
+      auto tracer = dynamic_cast<MockTracer *>(result->get());
+      REQUIRE(tracer->opts.report_hostname);
+    }
+    SECTION("DD_TRACE_REPORT_HOSTNAME overrides config") {
+      ::setenv("DD_TRACE_REPORT_HOSTNAME", "false", 0);
+      std::string input{R"(
+      {
+        "service": "my-service",
+        "dd.trace.report-hostname": true
+      }
+      )"};
+      std::string error = "";
+      auto result = factory.MakeTracer(input.c_str(), error);
+      ::unsetenv("DD_TRACE_REPORT_HOSTNAME");
+
+      REQUIRE(error == "");
+      REQUIRE(result->get() != nullptr);
+      auto tracer = dynamic_cast<MockTracer *>(result->get());
+      REQUIRE(!tracer->opts.report_hostname);
+    }
+    SECTION("DD_TRACE_ANALYTICS_ENABLED overrides default") {
+      ::setenv("DD_TRACE_ANALYTICS_ENABLED", "true", 0);
+      std::string input{R"(
+      {
+        "service": "my-service"
+      }
+      )"};
+      std::string error = "";
+      auto result = factory.MakeTracer(input.c_str(), error);
+      ::unsetenv("DD_TRACE_ANALYTICS_ENABLED");
+
+      REQUIRE(error == "");
+      REQUIRE(result->get() != nullptr);
+      auto tracer = dynamic_cast<MockTracer *>(result->get());
+      REQUIRE(tracer->opts.analytics_enabled);
+      REQUIRE(tracer->opts.analytics_rate == 1.0);
+    }
+    SECTION("DD_TRACE_ANALYTICS_ENABLED overrides config") {
+      ::setenv("DD_TRACE_ANALYTICS_ENABLED", "false", 0);
+      std::string input{R"(
+      {
+        "service": "my-service",
+        "dd.trace.analytics-enabled": true
+      }
+      )"};
+      std::string error = "";
+      auto result = factory.MakeTracer(input.c_str(), error);
+      ::unsetenv("DD_TRACE_ANALYTICS_ENABLED");
+
+      REQUIRE(error == "");
+      REQUIRE(result->get() != nullptr);
+      auto tracer = dynamic_cast<MockTracer *>(result->get());
+      REQUIRE(!tracer->opts.analytics_enabled);
+      REQUIRE(std::isnan(tracer->opts.analytics_rate));
     }
   }
 }

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -5,8 +5,6 @@
 // Source file needed to ensure compilation of templated class TracerFactory<MockTracer>
 #include "../src/tracer_factory.cpp"
 
-#include <unistd.h>
-
 #include <catch2/catch.hpp>
 using namespace datadog::opentracing;
 

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -24,6 +24,13 @@ void requireTracerOptionsResultsMatch(const ot::expected<TracerOptions, const ch
   REQUIRE(lhs->operation_name_override == rhs->operation_name_override);
   REQUIRE(lhs->extract == rhs->extract);
   REQUIRE(lhs->inject == rhs->inject);
+  REQUIRE(lhs->report_hostname == rhs->report_hostname);
+  REQUIRE(lhs->analytics_enabled == rhs->analytics_enabled);
+  if (std::isnan(lhs->analytics_rate)) {
+    REQUIRE(std::isnan(rhs->analytics_rate));
+  } else {
+    REQUIRE(lhs->analytics_rate == rhs->analytics_rate);
+  }
 };
 
 TEST_CASE("tracer options from environment variables") {
@@ -39,7 +46,10 @@ TEST_CASE("tracer options from environment variables") {
         {"DD_TRACE_AGENT_PORT", "420"},
         {"DD_ENV", "env"},
         {"DD_PROPAGATION_STYLE_EXTRACT", "B3 Datadog"},
-        {"DD_PROPAGATION_STYLE_INJECT", "Datadog B3"}},
+        {"DD_PROPAGATION_STYLE_INJECT", "Datadog B3"},
+        {"DD_TRACE_REPORT_HOSTNAME", "true"},
+        {"DD_TRACE_ANALYTICS_ENABLED", "true"},
+        {"DD_TRACE_ANALYTICS_SAMPLE_RATE", "0.5"}},
        TracerOptions{"host",
                      420,
                      "",
@@ -50,7 +60,10 @@ TEST_CASE("tracer options from environment variables") {
                      1000,
                      "",
                      {PropagationStyle::Datadog, PropagationStyle::B3},
-                     {PropagationStyle::Datadog, PropagationStyle::B3}}},
+                     {PropagationStyle::Datadog, PropagationStyle::B3},
+                     true,
+                     true,
+                     0.5}},
       {{{"DD_PROPAGATION_STYLE_EXTRACT", "Not even a real style"}},
        ot::make_unexpected("Value for DD_PROPAGATION_STYLE_EXTRACT is invalid")},
       {{{"DD_PROPAGATION_STYLE_INJECT", "Not even a real style"}},
@@ -59,6 +72,12 @@ TEST_CASE("tracer options from environment variables") {
        ot::make_unexpected("Value for DD_TRACE_AGENT_PORT is invalid")},
       {{{"DD_TRACE_AGENT_PORT", "9223372036854775807"}},
        ot::make_unexpected("Value for DD_TRACE_AGENT_PORT is out of range")},
+      {{{"DD_TRACE_REPORT_HOSTNAME", "yes please"}},
+       ot::make_unexpected("Value for DD_TRACE_REPORT_HOSTNAME is invalid")},
+      {{{"DD_TRACE_ANALYTICS_ENABLED", "yes please"}},
+       ot::make_unexpected("Value for DD_TRACE_ANALYTICS_ENABLED is invalid")},
+      {{{"DD_TRACE_ANALYTICS_SAMPLE_RATE", "1.1"}},
+       ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid")},
   }));
 
   // Setup

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -1,5 +1,4 @@
 #include "../src/tracer.h"
-#include <unistd.h>
 #include <ctime>
 #include "../src/sample.h"
 #include "../src/span.h"
@@ -116,74 +115,5 @@ TEST_CASE("tracer") {
     // Tag should not exist on the child span(s).
     auto& child_result = buffer->traces(100).finished_spans->at(0);
     REQUIRE(child_result->metrics.find("_dd1.sr.eausr") == child_result->metrics.end());
-  }
-}
-
-TEST_CASE("env overrides") {
-  int id = 100;  // Starting span id.
-  // Starting calendar time 2007-03-12 00:00:00
-  std::tm start{};
-  start.tm_mday = 12;
-  start.tm_mon = 2;
-  start.tm_year = 107;
-  TimePoint time{std::chrono::system_clock::from_time_t(timegm(&start)),
-                 std::chrono::steady_clock::time_point{}};
-  // auto buffer = std::make_shared<MockBuffer>();
-  TimeProvider get_time = [&time]() { return time; };  // Mock clock.
-  IdProvider get_id = [&id]() { return id++; };        // Mock ID provider.
-  auto sampler = std::make_shared<KeepAllSampler>();
-  auto mwriter = std::make_shared<MockWriter>(sampler);
-  auto writer = std::shared_ptr<Writer>(mwriter);
-  TracerOptions tracer_options{"", 0, "service_name", "web"};
-  const ot::StartSpanOptions span_options;
-
-  struct EnvOverrideTest {
-    std::string env;
-    std::string val;
-    std::string hostname;
-    double rate;
-  };
-
-  char buf[256];
-  ::gethostname(buf, 256);
-  std::string hostname(buf);
-
-  auto env_test = GENERATE_COPY(
-      values<EnvOverrideTest>({// Normal cases
-                               {"DD_TRACE_REPORT_HOSTNAME", "true", hostname, std::nan("")},
-                               {"DD_TRACE_ANALYTICS_ENABLED", "true", "", 1.0},
-                               {"DD_TRACE_ANALYTICS_ENABLED", "false", "", 0.0},
-                               {"DD_GLOBAL_ANALYTICS_SAMPLE_RATE", "0.5", "", 0.5},
-                               {"", "", "", std::nan("")},
-                               // Unexpected values handled gracefully
-                               {"DD_TRACE_ANALYTICS_ENABLED", "yes please", "", std::nan("")},
-                               {"DD_GLOBAL_ANALYTICS_SAMPLE_RATE", "1.1", "", std::nan("")},
-                               {"DD_GLOBAL_ANALYTICS_SAMPLE_RATE", "half", "", std::nan("")}}));
-
-  SECTION("set correct tags and metrics") {
-    // Setup
-    ::setenv(env_test.env.c_str(), env_test.val.c_str(), 0);
-    std::shared_ptr<Tracer> tracer{new Tracer{tracer_options, writer, sampler}};
-
-    // Create span
-    auto span = tracer->StartSpanWithOptions("/env-override", span_options);
-    const ot::FinishSpanOptions finish_options;
-    span->FinishWithOptions(finish_options);
-
-    auto& result = mwriter->traces[0][0];
-    // Check the analytics rate matches the expected value.
-    if (env_test.hostname.empty()) {
-      REQUIRE(result->meta.find("_dd.hostname") == result->meta.end());
-    } else {
-      REQUIRE(result->meta["_dd.hostname"] == env_test.hostname);
-    }
-    // Check the analytics rate matches the expected value.
-    if (std::isnan(env_test.rate)) {
-      REQUIRE(result->metrics.find("_dd1.sr.eausr") == result->metrics.end());
-    } else {
-      REQUIRE(result->metrics["_dd1.sr.eausr"] == env_test.rate);
-    }
-    // Tear-down
-    ::unsetenv(env_test.env.c_str());
   }
 }


### PR DESCRIPTION
This was requested in #110 in relation to `ingress-nginx`.
Some options in the tracer were only configurable via environment variables.
This doesn't work well for nginx because it ignores most environment variables when launching unless explicitly configured to keep them.
In that circumstance, it's easier to expose them via the tracer's JSON config.

Fixes #110 
