### PR TITLE
Revert "Expose sampling decision to external tracers"

### DIFF
--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -88,8 +88,6 @@ class TraceEncoder {
   virtual const std::string payload() = 0;
   // Receives and handles the response from the Agent.
   virtual void handleResponse(const std::string& response) = 0;
-  //
-  virtual bool sampled(const ot::SpanContext& ctx, bool) = 0;
 };
 
 // makeTracer returns an opentracing::Tracer that submits traces to the Datadog Agent.

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -77,18 +77,5 @@ void AgentHttpEncoder::handleResponse(const std::string& response) {
   }
 }
 
-bool AgentHttpEncoder::sampled(const ot::SpanContext& ctx, bool fallback_decision) try {
-  auto context = dynamic_cast<const SpanContext*>(&ctx);
-  if (context != nullptr) {
-    OptionalSamplingPriority p = context->getPropagatedSamplingPriority();
-    if (p != nullptr) {
-      return *p > SamplingPriority::SamplerDrop;
-    }
-  }
-  return fallback_decision;
-} catch (std::bad_cast&) {
-  return fallback_decision;
-}
-
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -29,7 +29,6 @@ class AgentHttpEncoder : public TraceEncoder {
   // Returns the encoded payload from the collection of traces.
   const std::string payload() override;
   void handleResponse(const std::string& response) override;
-  bool sampled(const ot::SpanContext& ctx, bool fallback_decision) override;
   void addTrace(Trace trace);
 
  private:


### PR DESCRIPTION
Reverts DataDog/dd-opentracing-cpp#121

This didn't have the intended effect, so it needs reverting before shipping the next release.