### PR TITLE
Fix build and launch issues for the compiled-in example

### DIFF
--- a/examples/cpp-tracing/compiled-in/Dockerfile
+++ b/examples/cpp-tracing/compiled-in/Dockerfile
@@ -20,7 +20,7 @@ RUN get_latest_release() { \
 
 COPY tracer_example.cpp .
 
-RUN g++ -std=c++14 -o tracer_example tracer_example.cpp -ldd_opentracing -lopentracing
+RUN g++ -std=c++14 -o tracer_example tracer_example.cpp -I/dd-opentracing-cpp/deps/include -L/dd-opentracing-cpp/deps/lib -ldd_opentracing -lopentracing
 # Add /usr/local/lib to LD_LIBRARY_PATH
 RUN ldconfig
 

--- a/examples/cpp-tracing/compiled-in/docker-compose.yml
+++ b/examples/cpp-tracing/compiled-in/docker-compose.yml
@@ -15,5 +15,3 @@ services:
       - 'DD_APM_ENABLED=true'
       - DD_API_KEY
     image: 'datadog/agent'
-    ports:
-        - "127.0.0.1:8126:8126"


### PR DESCRIPTION
Because of other changes, this wouldn't build without the additional compiler flags.

Removed port binding from docker-compose as well. It's not needed, and can conflict with other things happening on the host.