### PR TITLE
Add support for traces sent using UNIX domain sockets

### DIFF
--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -82,9 +82,11 @@ struct TracerOptions {
   // The version of the overall application being traced. Can also be set by the environment
   // variable DD_VERSION.
   std::string version = "";
-  // The path of the UNIX Domain Socket that can be used for sending traces to the agent.
-  // Can also be set by the environment variable DD_TRACE_AGENT_SOCKET.
-  std::string agent_socket = "";
+  // The URL to use for submitting traces to the agent. If set, this will be used instead of
+  // agent_host / agent_port. This URL supports http, https and unix address schemes.
+  // If no scheme is set in the URL, a path to a UNIX domain socket is assumed.
+  // Can also be set by the environment variable DD_TRACE_AGENT_URL.
+  std::string agent_url = "";
 };
 
 // TraceEncoder exposes the data required to encode and submit traces to the

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -82,6 +82,9 @@ struct TracerOptions {
   // The version of the overall application being traced. Can also be set by the environment
   // variable DD_VERSION.
   std::string version = "";
+  // The path of the UNIX Domain Socket that can be used for sending traces to the agent.
+  // Can also be set by the environment variable DD_TRACE_AGENT_SOCKET.
+  std::string agent_socket = "";
 };
 
 // TraceEncoder exposes the data required to encode and submit traces to the

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -49,6 +49,7 @@ void AgentWriter::setUpHandle(std::unique_ptr<Handle> &handle, std::string host,
   // - https://host:port
   // - unix:///path/to/trace-agent.socket
   // - /path/to/trace-agent.socket
+  bool urlopt_set = false;
   if (!url.empty()) {
     const std::string http_scheme = "http://";
     const std::string https_scheme = "https://";
@@ -62,6 +63,7 @@ void AgentWriter::setUpHandle(std::unique_ptr<Handle> &handle, std::string host,
         throw std::runtime_error(std::string("Unable to set agent URL: ") +
                                  curl_easy_strerror(rcode));
       }
+      urlopt_set = true;
     } else if (url.substr(0, unix_scheme.size()) == unix_scheme) {
       // unix://
       url = url.substr(unix_scheme.size());
@@ -80,7 +82,8 @@ void AgentWriter::setUpHandle(std::unique_ptr<Handle> &handle, std::string host,
     } else {
       throw std::runtime_error(std::string("Unable to set agent URL: unknown url scheme: " + url));
     }
-  } else {
+  }
+  if (!urlopt_set) {
     std::string agent_uri =
         agent_protocol + host + ":" + std::to_string(port) + trace_encoder_->path();
     auto rcode = handle->setopt(CURLOPT_URL, agent_uri.c_str());

--- a/src/agent_writer.h
+++ b/src/agent_writer.h
@@ -23,12 +23,13 @@ class AgentWriter : public Writer {
  public:
   // Creates an AgentWriter that uses curl to send Traces to a Datadog agent. May throw a
   // runtime_exception.
-  AgentWriter(std::string host, uint32_t port, std::chrono::milliseconds write_period,
-              std::shared_ptr<RulesSampler> sampler);
+  AgentWriter(std::string host, uint32_t port, std::string unix_socket,
+              std::chrono::milliseconds write_period, std::shared_ptr<RulesSampler> sampler);
 
   AgentWriter(std::unique_ptr<Handle> handle, std::chrono::milliseconds write_period,
               size_t max_queued_traces, std::vector<std::chrono::milliseconds> retry_periods,
-              std::string host, uint32_t port, std::shared_ptr<RulesSampler> sampler);
+              std::string host, uint32_t port, std::string unix_socket,
+              std::shared_ptr<RulesSampler> sampler);
 
   // Does not flush on destruction, buffered traces may be lost. Stops all threads.
   ~AgentWriter() override;
@@ -44,7 +45,8 @@ class AgentWriter : public Writer {
 
  private:
   // Initialises the curl handle. May throw a runtime_exception.
-  void setUpHandle(std::unique_ptr<Handle> &handle, std::string host, uint32_t port);
+  void setUpHandle(std::unique_ptr<Handle> &handle, std::string host, uint32_t port,
+                   std::string unix_socket);
 
   // Starts asynchronously writing traces. They will be written periodically (set by write_period_)
   // or when flush() is called manually.

--- a/src/opentracing_agent.cpp
+++ b/src/opentracing_agent.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options) {
 
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::shared_ptr<Writer>{
-      new AgentWriter(opts.agent_host, opts.agent_port, opts.agent_socket,
+      new AgentWriter(opts.agent_host, opts.agent_port, opts.agent_url,
                       std::chrono::milliseconds(llabs(opts.write_period_ms)), sampler)};
   return std::shared_ptr<ot::Tracer>{new Tracer{opts, writer, sampler}};
 }

--- a/src/opentracing_agent.cpp
+++ b/src/opentracing_agent.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options) {
 
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::shared_ptr<Writer>{
-      new AgentWriter(opts.agent_host, opts.agent_port,
+      new AgentWriter(opts.agent_host, opts.agent_port, opts.agent_socket,
                       std::chrono::milliseconds(llabs(opts.write_period_ms)), sampler)};
   return std::shared_ptr<ot::Tracer>{new Tracer{opts, writer, sampler}};
 }

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -33,8 +33,8 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
     if (config.find("agent_port") != config.end()) {
       config.at("agent_port").get_to(options.agent_port);
     }
-    if (config.find("agent_socket") != config.end()) {
-      config.at("agent_socket").get_to(options.agent_socket);
+    if (config.find("agent_url") != config.end()) {
+      config.at("agent_url").get_to(options.agent_url);
     }
     if (config.find("type") != config.end()) {
       config.at("type").get_to(options.type);
@@ -136,7 +136,7 @@ ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
 
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::shared_ptr<Writer>{
-      new AgentWriter(options.agent_host, options.agent_port, options.agent_socket,
+      new AgentWriter(options.agent_host, options.agent_port, options.agent_url,
                       std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
 
   return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -33,6 +33,9 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
     if (config.find("agent_port") != config.end()) {
       config.at("agent_port").get_to(options.agent_port);
     }
+    if (config.find("agent_socket") != config.end()) {
+      config.at("agent_socket").get_to(options.agent_socket);
+    }
     if (config.find("type") != config.end()) {
       config.at("type").get_to(options.type);
     }
@@ -133,7 +136,7 @@ ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
 
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::shared_ptr<Writer>{
-      new AgentWriter(options.agent_host, options.agent_port,
+      new AgentWriter(options.agent_host, options.agent_port, options.agent_socket,
                       std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
 
   return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -129,9 +129,9 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
     opts.sampling_rules = sampling_rules;
   }
 
-  auto trace_agent_socket = std::getenv("DD_TRACE_AGENT_SOCKET");
-  if (trace_agent_socket != nullptr && std::strlen(trace_agent_socket) > 0) {
-    opts.agent_socket = trace_agent_socket;
+  auto trace_agent_url = std::getenv("DD_TRACE_AGENT_URL");
+  if (trace_agent_url != nullptr && std::strlen(trace_agent_url) > 0) {
+    opts.agent_url = trace_agent_url;
   }
 
   auto extract = std::getenv("DD_PROPAGATION_STYLE_EXTRACT");

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -129,6 +129,11 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
     opts.sampling_rules = sampling_rules;
   }
 
+  auto trace_agent_socket = std::getenv("DD_TRACE_AGENT_SOCKET");
+  if (trace_agent_socket != nullptr && std::strlen(trace_agent_socket) > 0) {
+    opts.agent_socket = trace_agent_socket;
+  }
+
   auto extract = std::getenv("DD_PROPAGATION_STYLE_EXTRACT");
   if (extract != nullptr && std::strlen(extract) > 0) {
     std::stringstream words{extract};

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -32,6 +32,7 @@ TEST_CASE("writer") {
                      disable_retry,
                      "hostname",
                      6319,
+                     "",
                      sampler};
 
   SECTION("initilises handle correctly") {
@@ -142,7 +143,7 @@ TEST_CASE("writer") {
     std::unique_ptr<MockHandle> handle_ptr{new MockHandle{}};
     handle_ptr->rcode = CURLE_OPERATION_TIMEDOUT;
     REQUIRE_THROWS(AgentWriter{std::move(handle_ptr), only_send_traces_when_we_flush,
-                               max_queued_traces, disable_retry, "hostname", 6319,
+                               max_queued_traces, disable_retry, "hostname", 6319, "",
                                std::make_shared<RulesSampler>()});
   }
 
@@ -253,6 +254,7 @@ TEST_CASE("writer") {
                        disable_retry,
                        "hostname",
                        6319,
+                       "",
                        std::make_shared<RulesSampler>()};
     // Send 7 traces at 1 trace per second. Since the write period is 2s, there should be 4
     // different writes. We don't count the number of writes because that could flake, but we do
@@ -291,6 +293,7 @@ TEST_CASE("writer") {
                        retry_periods,
                        "hostname",
                        6319,
+                       "",
                        std::make_shared<RulesSampler>()};
     // Redirect cerr, so the the terminal output doesn't imply failure.
     std::stringstream error_message;
@@ -346,6 +349,7 @@ TEST_CASE("flush") {
                      retry_periods,
                      "hostname",
                      6319,
+                     "",
                      std::make_shared<RulesSampler>()};
   // Redirect cerr, so the the terminal output doesn't imply failure.
   std::stringstream error_message;

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -440,8 +440,8 @@ TEST_CASE("tracer factory") {
       REQUIRE(tracer->opts.sampling_rules == sampling_rules);
     }
 
-    SECTION("DD_TRACE_AGENT_SOCKET overrides default") {
-      ::setenv("DD_TRACE_AGENT_SOCKET", "/path/to/trace-agent.socket", 0);
+    SECTION("DD_TRACE_AGENT_URL overrides default") {
+      ::setenv("DD_TRACE_AGENT_URL", "/path/to/trace-agent.socket", 0);
       std::string input{R"(
       {
         "service": "my-service"
@@ -449,31 +449,31 @@ TEST_CASE("tracer factory") {
       )"};
       std::string error = "";
       auto result = factory.MakeTracer(input.c_str(), error);
-      ::unsetenv("DD_TRACE_AGENT_SOCKET");
+      ::unsetenv("DD_TRACE_AGENT_URL");
 
       REQUIRE(error == "");
       REQUIRE(result->get() != nullptr);
       auto tracer = dynamic_cast<MockTracer *>(result->get());
       REQUIRE(tracer->opts.service == "my-service");
-      REQUIRE(tracer->opts.agent_socket == "/path/to/trace-agent.socket");
+      REQUIRE(tracer->opts.agent_url == "/path/to/trace-agent.socket");
     }
-    SECTION("DD_TRACE_AGENT_SOCKET overrides configuration") {
-      ::setenv("DD_TRACE_AGENT_SOCKET", "/path/to/trace-agent.socket", 0);
+    SECTION("DD_TRACE_AGENT_URL overrides configuration") {
+      ::setenv("DD_TRACE_AGENT_URL", "/path/to/trace-agent.socket", 0);
       std::string input{R"(
       {
         "service": "my-service",
-        "agent_socket": "/configured/trace-agent.socket"
+        "agent_url": "/configured/trace-agent.socket"
       }
       )"};
       std::string error = "";
       auto result = factory.MakeTracer(input.c_str(), error);
-      ::unsetenv("DD_TRACE_AGENT_SOCKET");
+      ::unsetenv("DD_TRACE_AGENT_URL");
 
       REQUIRE(error == "");
       REQUIRE(result->get() != nullptr);
       auto tracer = dynamic_cast<MockTracer *>(result->get());
       REQUIRE(tracer->opts.service == "my-service");
-      REQUIRE(tracer->opts.agent_socket == "/path/to/trace-agent.socket");
+      REQUIRE(tracer->opts.agent_url == "/path/to/trace-agent.socket");
     }
 
     SECTION("DD_TRACE_REPORT_HOSTNAME overrides default") {


### PR DESCRIPTION
Fixes #125 

Lets users provide a path to the trace-agent socket in addition to the agent's host/port.
This PR doesn't include an integration test (yet) but it has been tested locally.

The agent needs to have the `DD_APM_RECEIVER_SOCKET` environment variable set, and the C++ application needs to have the same path configured in JSON or using the `DD_TRACE_AGENT_SOCKET` environment variable.

In containerized setups (eg: kubernetes), the directory containing the socket should be mounted by both agent container and the application submitting traces.