### PR TITLE
Small fixes for macos / clang builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .build/
 
 # Locally installed dependencies
-.deps/
+deps/
 
 # Compiled Object files
 *.slo

--- a/include/datadog/version.h
+++ b/include/datadog/version.h
@@ -6,7 +6,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.1.4";
+const std::string tracer_version = "v1.1.5";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -60,10 +60,13 @@ LimitResult Limiter::allow(long tokens_requested) {
   num_requested_++;
   // refill "tokens"
   if (now >= next_refresh_) {
-    auto intervals = (now - next_refresh_) / refresh_interval_ + 1;
+    auto intervals = (now - next_refresh_).count() / refresh_interval_.count() + 1;
     if (intervals > 0) {
-      next_refresh_ += (refresh_interval_ * intervals);
-      num_tokens_ = std::min(max_tokens_, num_tokens_ + intervals * tokens_per_refresh_);
+      next_refresh_ += refresh_interval_ * intervals;
+      num_tokens_ += intervals * tokens_per_refresh_;
+      if (num_tokens_ > max_tokens_) {
+        num_tokens_ = max_tokens_;
+      }
     }
   }
   // determine if allowed or not

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,8 @@ add_library(catch STATIC test_main.cpp)
 macro(_datadog_test TEST_NAME)
   add_executable(${TEST_NAME} ${ARGN})
   add_sanitizers(${TEST_NAME})  
-  target_link_libraries(${TEST_NAME} ${DATADOG_LINK_LIBRARIES}
-                                     dd_opentracing
+  target_link_libraries(${TEST_NAME} dd_opentracing
+                                     ${DATADOG_LINK_LIBRARIES}
                                      catch)
   add_test(${TEST_NAME} ${TEST_NAME})
 endmacro()


### PR DESCRIPTION
Under some environments, `std::chrono::duration` uses `long` for representing the value, and others use `long long`. In the latter, it caused an error comparing against a `long` using `std::min`.
It could have been fixed using `std::common_type`, but a simpler fix with a basic if comparison was chosen instead.

When running tests on macos, one specific test would fail in a mysterious way, when comparing against an essentially static value. This was somehow due to the orders libraries were linked causing trouble on this environment. (It didn't occur with Linux/GCC).