### PR TITLE
Add example configs for major envoy versions

### DIFF
--- a/examples/envoy-tracing/check_envoy_configs.sh
+++ b/examples/envoy-tracing/check_envoy_configs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+required_tools=( docker docker-compose curl )
+for i in ${required_tools[@]}; do
+	if ! binary=$(type -P "$i"); then
+		echo "Missing required tool: $i"
+		exit 1
+	fi
+	if ! [[ -x $binary ]]; then
+		echo "Required tool is not executable: $i ( $binary )"
+		exit 1
+	fi
+done
+
+if ! cd "${0%/*}"; then
+	echo "failed to change working directory: ${0%/*}"
+	exit 1
+fi
+
+configs=( envoy-*.yaml )
+for i in "${configs[@]}"; do
+	x=${i#envoy-}
+	x=${x%.yaml}
+	versions+=( $x )
+done
+
+docker-compose rm -f
+docker-compose up -d
+for i in "${versions[@]}"; do
+	if ! IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "envoy-tracing_envoy-${i}_1"); then
+		echo "failed checking $i: unable to retrieve IP address for envoy-tracing_envoy-${i}_1"
+		continue
+	fi
+	curl -w "\n" "http://$IP/" "http://$IP/healthcheck"
+done
+sleep 1
+echo "check for traces at https://app.datadoghq.com/apm/livetail or https://app.datadoghq.com/apm/traces"
+sleep 5
+docker-compose kill

--- a/examples/envoy-tracing/docker-compose.yml
+++ b/examples/envoy-tracing/docker-compose.yml
@@ -1,0 +1,81 @@
+version: "3.2"
+services:
+  dd-agent:
+    environment:
+      - DD_API_KEY
+      - DD_APM_ENABLED=true
+    image: 'datadog/agent'
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/proc/:/host/proc/:ro'
+      - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
+
+  envoy-ed6a1b8:
+    image: envoyproxy/envoy-dev:ed6a1b8b60a23e6bae7f08f990d1680b26b26cde
+    depends_on:
+      - dd-agent
+    entrypoint: []
+    command:
+      - envoy
+      - -l
+      - debug
+      - -c
+      - /etc/envoy/envoy.yaml
+    volumes:
+      - './envoy-ed6a1b8.yaml:/etc/envoy/envoy.yaml:ro'
+
+  envoy-v1.14:
+    image: envoyproxy/envoy:v1.14.1
+    depends_on:
+      - dd-agent
+    entrypoint: []
+    command:
+      - envoy
+      - -l
+      - debug
+      - -c
+      - /etc/envoy/envoy.yaml
+    volumes:
+      - './envoy-v1.14.yaml:/etc/envoy/envoy.yaml:ro'
+
+  envoy-v1.13:
+    image: envoyproxy/envoy:v1.13.1
+    depends_on:
+      - dd-agent
+    entrypoint: []
+    command:
+      - envoy
+      - -l
+      - debug
+      - -c
+      - /etc/envoy/envoy.yaml
+    volumes:
+      - './envoy-v1.13.yaml:/etc/envoy/envoy.yaml:ro'
+
+  envoy-v1.12:
+    image: envoyproxy/envoy:v1.12.3
+    depends_on:
+      - dd-agent
+    entrypoint: []
+    command:
+      - envoy
+      - -l
+      - debug
+      - -c
+      - /etc/envoy/envoy.yaml
+    volumes:
+      - './envoy-v1.12.yaml:/etc/envoy/envoy.yaml:ro'
+
+  envoy-v1.11:
+    image: envoyproxy/envoy:v1.11.2
+    depends_on:
+      - dd-agent
+    entrypoint: []
+    command:
+      - envoy
+      - -l
+      - debug
+      - -c
+      - /etc/envoy/envoy.yaml
+    volumes:
+      - './envoy-v1.11.yaml:/etc/envoy/envoy.yaml:ro'

--- a/examples/envoy-tracing/envoy-ed6a1b8.yaml
+++ b/examples/envoy-tracing/envoy-ed6a1b8.yaml
@@ -1,0 +1,85 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    traffic_direction: OUTBOUND
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          generate_request_id: true
+          tracing: {}
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service1
+          http_filters:
+          # Traces for healthcheck requests should not be sampled.
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              pass_through_mode: false
+              headers:
+                - exact_match: /healthcheck
+                  name: :path
+          - name: envoy.filters.http.router
+            typed_config: {}
+          use_remote_address: true
+  clusters:
+  - name: service1
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service1
+                port_value: 80
+  # Configure this cluster with the address of the datadog agent
+  # for sending traces.
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: dd-agent
+                port_value: 8126
+
+tracing:
+  # Use the datadog tracer
+  http:
+    name: envoy.tracers.datadog
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
+      collector_cluster: datadog_agent   # matched against the named cluster below
+      service_name: envoy-example        # user-defined service name
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/envoy-tracing/envoy-v1.11.yaml
+++ b/examples/envoy-tracing/envoy-v1.11.yaml
@@ -1,0 +1,86 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    traffic_direction: OUTBOUND
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          generate_request_id: true
+          tracing:
+            operation_name: egress
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service1
+          http_filters:
+          # Traces for healthcheck requests should not be sampled.
+          - name: envoy.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              pass_through_mode: false
+              headers:
+                - exact_match: /healthcheck
+                  name: :path
+          - name: envoy.router
+            typed_config: {}
+          use_remote_address: true
+  clusters:
+  - name: service1
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service1
+                port_value: 80
+  # Configure this cluster with the address of the datadog agent
+  # for sending traces.
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: dd-agent
+                port_value: 8126
+
+tracing:
+  # Use the datadog tracer
+  http:
+    name: envoy.tracers.datadog
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
+      collector_cluster: datadog_agent   # matched against the named cluster below
+      service_name: envoy-example        # user-defined service name
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/envoy-tracing/envoy-v1.12.yaml
+++ b/examples/envoy-tracing/envoy-v1.12.yaml
@@ -1,0 +1,85 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    traffic_direction: OUTBOUND
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          generate_request_id: true
+          tracing: {}
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service1
+          http_filters:
+          # Traces for healthcheck requests should not be sampled.
+          - name: envoy.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              pass_through_mode: false
+              headers:
+                - exact_match: /healthcheck
+                  name: :path
+          - name: envoy.router
+            typed_config: {}
+          use_remote_address: true
+  clusters:
+  - name: service1
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service1
+                port_value: 80
+  # Configure this cluster with the address of the datadog agent
+  # for sending traces.
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: dd-agent
+                port_value: 8126
+
+tracing:
+  # Use the datadog tracer
+  http:
+    name: envoy.tracers.datadog
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
+      collector_cluster: datadog_agent   # matched against the named cluster below
+      service_name: envoy-example        # user-defined service name
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/envoy-tracing/envoy-v1.13.yaml
+++ b/examples/envoy-tracing/envoy-v1.13.yaml
@@ -1,0 +1,85 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    traffic_direction: OUTBOUND
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          generate_request_id: true
+          tracing: {}
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service1
+          http_filters:
+          # Traces for healthcheck requests should not be sampled.
+          - name: envoy.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              pass_through_mode: false
+              headers:
+                - exact_match: /healthcheck
+                  name: :path
+          - name: envoy.router
+            typed_config: {}
+          use_remote_address: true
+  clusters:
+  - name: service1
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service1
+                port_value: 80
+  # Configure this cluster with the address of the datadog agent
+  # for sending traces.
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: dd-agent
+                port_value: 8126
+
+tracing:
+  # Use the datadog tracer
+  http:
+    name: envoy.tracers.datadog
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
+      collector_cluster: datadog_agent   # matched against the named cluster below
+      service_name: envoy-example        # user-defined service name
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/envoy-tracing/envoy-v1.14.yaml
+++ b/examples/envoy-tracing/envoy-v1.14.yaml
@@ -1,0 +1,85 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    traffic_direction: OUTBOUND
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          generate_request_id: true
+          tracing: {}
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service1
+          http_filters:
+          # Traces for healthcheck requests should not be sampled.
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              pass_through_mode: false
+              headers:
+                - exact_match: /healthcheck
+                  name: :path
+          - name: envoy.filters.http.router
+            typed_config: {}
+          use_remote_address: true
+  clusters:
+  - name: service1
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: service1
+                port_value: 80
+  # Configure this cluster with the address of the datadog agent
+  # for sending traces.
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: service1
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: dd-agent
+                port_value: 8126
+
+tracing:
+  # Use the datadog tracer
+  http:
+    name: envoy.tracers.datadog
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
+      collector_cluster: datadog_agent   # matched against the named cluster below
+      service_name: envoy-example        # user-defined service name
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001


### PR DESCRIPTION
Adding static runnable examples for envoy across recent major versions.
There's small differences between each version when configuring tracing, and sometimes these tiny details make the difference between making things work successfully and not working at all.
I need to put these somewhere so a reference to "older versions" can be added to the main documentation.