### PR TITLE
Update nginx example, make dockerfile useful as reference

### DIFF
--- a/examples/nginx-tracing/Dockerfile
+++ b/examples/nginx-tracing/Dockerfile
@@ -1,23 +1,10 @@
-# Builds and runs a simple nginx server, traced by Datadog
-FROM ubuntu:18.04
+# An nginx container that includes the module and plugin required for Datadog tracing.
+FROM nginx:1.17.3
 
-ARG NGINX_VERSION=1.14.2
+ARG NGINX_VERSION=1.17.3
 
 RUN apt-get update && \
-  apt-get install -y git gnupg wget tar
-
-# Install nginx
-RUN wget https://nginx.org/keys/nginx_signing.key && \
-  apt-key add nginx_signing.key && \
-  echo deb https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
-  echo deb-src https://nginx.org/packages/ubuntu/ bionic nginx >> /etc/apt/sources.list && \
-  apt-get update && \
-  apt-get install nginx=${NGINX_VERSION}-1~bionic
-# Configure nginx
-COPY ./examples/nginx-tracing/nginx.conf /etc/nginx/nginx.conf
-COPY ./examples/nginx-tracing/dd-config.json /etc/dd-config.json
-RUN mkdir -p /var/www/
-COPY ./examples/nginx-tracing/index.html /var/www/index.html
+  apt-get install -y wget tar
 
 # Install nginx-opentracing
 RUN get_latest_release() { \
@@ -31,9 +18,3 @@ RUN get_latest_release() { \
   tar zxvf linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz -C "${NGINX_MODULES}" && \
   # Install Datadog module
   wget -O - https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libdd_opentracing_plugin.so
-
-# Test nginx config.
-RUN nginx -t
-
-EXPOSE 80
-CMD [ "nginx", "-g", "daemon off;"]

--- a/examples/nginx-tracing/docker-compose.yml
+++ b/examples/nginx-tracing/docker-compose.yml
@@ -2,8 +2,14 @@ version: "3.2"
 services:
   traced-nginx:
     build:
-      context: ../../
-      dockerfile: examples/nginx-tracing/Dockerfile
+      context: .
+      dockerfile: Dockerfile
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "nginx", "service": "traced-nginx"}]'
+    volumes:
+      - './nginx.conf:/etc/nginx/nginx.conf:ro'
+      - './dd-config.json:/etc/nginx/dd-config.json:ro'
+      - './index.html:/usr/share/nginx/html/index.html:ro'
     ports:
       - "8080:80"
   dd-agent:
@@ -14,5 +20,8 @@ services:
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
       - DD_API_KEY
-      - 'DD_APM_ENABLED=true'
+      - DD_APM_ENABLED=true
+      - DD_LOGS_ENABLED=true
+      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+      - DD_AC_EXCLUDE=name:datadog-agent
     image: 'datadog/agent'

--- a/examples/nginx-tracing/nginx.conf
+++ b/examples/nginx-tracing/nginx.conf
@@ -5,26 +5,32 @@ events {
 }
 
 http {
+    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
+
     opentracing on;
     opentracing_tag http_user_agent $http_user_agent;
     opentracing_trace_locations off;
+    opentracing_operation_name "$request_method $uri";
 
-    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/dd-config.json;
+    log_format with_trace_id '$remote_addr - $http_x_forwarded_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for" '
+        '"$opentracing_context_x_datadog_trace_id" "$opentracing_context_x_datadog_parent_id"';
+
+    access_log /var/log/nginx/access.log with_trace_id;
 
     server {
         listen       80;
         server_name  localhost;
 
         location / {
-            opentracing_operation_name "$request_method $uri";
-            opentracing_tag "resource.name" "/";
-            root /var/www/;
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            opentracing_tag "custom-tag" "special value";
         }
 
         location /test {
-            opentracing_operation_name "$request_method $uri";
-            opentracing_tag "resource.name" "/test";
-            alias /var/www/index.html;
+            alias /usr/share/nginx/html/index.html;
         }
     }
 }


### PR DESCRIPTION
Changing the dockerfile to use an `nginx` base image instead of `ubuntu` and then installing nginx. The `nginx` base image has extra rules that make access/error logs go to the container's `stdout`/`stderr`.

Also modified the `log_format` in `nginx.conf` to verify that logs and traces can be connected.
Note: it doesn't work OOTB with the existing NGINX logs integration, but can be made to work by duplicating it and updating the grok parser and adding a Trace ID Remapper.