### PR TITLE
Change URL obfuscation behavior

### DIFF
--- a/src/span.h
+++ b/src/span.h
@@ -92,7 +92,8 @@ class Span : public DatadogSpan {
   Span(std::shared_ptr<const Tracer> tracer, std::shared_ptr<SpanBuffer> buffer,
        TimeProvider get_time, uint64_t span_id, uint64_t trace_id, uint64_t parent_id,
        SpanContext context, TimePoint start_time, std::string span_service, std::string span_type,
-       std::string span_name, std::string resource, std::string operation_name_override);
+       std::string span_name, std::string resource, std::string operation_name_override,
+       bool legacy_obfuscation = false);
 
   Span() = delete;
   ~Span() override;
@@ -134,6 +135,7 @@ class Span : public DatadogSpan {
   SpanContext context_;
   TimePoint start_time_;
   std::string operation_name_override_;
+  bool legacy_obfuscation_ = false;
 
   // Set in constructor initializer, depends on previous constructor initializer-set members:
   std::unique_ptr<SpanData> span_;

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -74,6 +74,7 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   std::shared_ptr<SpanBuffer> buffer_;
   TimeProvider get_time_;
   IdProvider get_id_;
+  bool legacy_obfuscation_ = false;
 };
 
 }  // namespace opentracing

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -73,9 +73,10 @@ COPY ./test/integration/nginx/dd-config.json /etc/dd-config.json
 RUN mkdir -p /var/www/
 COPY ./test/integration/nginx/index.html /var/www/index.html
 
-COPY ./test/integration/nginx/nginx_integration_test.sh ./
-COPY ./test/integration/nginx/expected_*.json ./
 # TODO(cgilmour): Hack to pin a dep of msgpack-cli
 RUN git clone -b v1.1.2 https://github.com/ugorji/go /root/go/src/github.com/ugorji/go
 RUN go get github.com/jakm/msgpack-cli
+# Copy these last so that edits don't need as many image rebuild steps
+COPY ./test/integration/nginx/nginx_integration_test.sh ./
+COPY ./test/integration/nginx/expected_*.json ./
 CMD [ "bash", "-x", "./nginx_integration_test.sh"]

--- a/test/integration/nginx/expected_tc6.json
+++ b/test/integration/nginx/expected_tc6.json
@@ -8,7 +8,7 @@
         "http.method": "GET",
         "http.status_code": "200",
         "http.status_line": "200 OK",
-        "http.url": "http://localhost/proxy/?",
+        "http.url": "http://localhost/proxy/",
         "operation": "GET /proxy/"
       },
       "metrics": {


### PR DESCRIPTION
The `http.url` tag gets obfuscated too heavily, to the point where it's not very useful. It was also inconsistent with other tracers.
This PR makes it consistent with other tracers, but has an option to keep using the "legacy obfuscation" by setting an environment variable: `DD_TRACE_CPP_LEGACY_OBFUSCATION=1`

Fine-grained control of replacements can be configured on the agent using [tag filtering](https://docs.datadoghq.com/security/tracing/#tag-filtering)