### PR TITLE
Write tracer options to a log file at startup

### DIFF
--- a/src/tracer.h
+++ b/src/tracer.h
@@ -2,6 +2,7 @@
 #define DD_OPENTRACING_TRACER_H
 
 #include <datadog/opentracing.h>
+#include <datadog/version.h>
 #include <functional>
 #include <random>
 #include "clock.h"
@@ -22,6 +23,8 @@ class SpanBuffer;
 typedef std::function<uint64_t()> IdProvider;
 
 uint64_t getId();
+void logTracerOptions(std::chrono::time_point<std::chrono::system_clock> timestamp,
+                      TracerOptions &options, std::ostream &out);
 
 class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
  public:

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -240,3 +240,25 @@ TEST_CASE("env overrides") {
     ::unsetenv(env_test.env.c_str());
   }
 }
+
+TEST_CASE("startup log") {
+  TracerOptions opts;
+  opts.agent_url = "/path/to/unix.socket";
+  opts.analytics_rate = 0.3;
+  opts.tags.emplace("foo", "bar");
+  opts.tags.emplace("themeaningoflifetheuniverseandeverything", "42");
+  opts.operation_name_override = "meaningful.name";
+
+  auto now = std::chrono::system_clock::now();
+  std::stringstream ss;
+  logTracerOptions(now, opts, ss);
+
+  REQUIRE(!ss.str().empty());
+  json j;
+  ss >> j;  // May throw an exception
+  REQUIRE(j["date"].get<std::string>().size() == 24);
+  REQUIRE(j["agent_url"] == opts.agent_url);
+  REQUIRE(j["analytics_sample_rate"] == opts.analytics_rate);
+  REQUIRE(j["tags"] == opts.tags);
+  REQUIRE(j["operation_name_override"] == opts.operation_name_override);
+}


### PR DESCRIPTION
This can be disabled by setting the environment variable `DD_TRACE_STARTUP_LOGS=0`.
The purpose of these logs is to assist with troubleshooting, so there's a simple and definitive source of the settings that affect traces being captured and sent to the agent.

The log files are created in `/var/tmp/dd-opentracing-cpp`. An example filename is `/var/tmp/dd-opentracing-cpp/startup_options-1594274838900439942.json` with the contents:
```json
{"agent_url":"http://localhost:8126","analytics_enabled":false,"analytics_sample_rate":null,"date":"2020-07-09T06:07:18+0000","enabled":true,"env":"","lang":"cpp","lang_version":"201402","report_hostname":false,"sampling_rules":"[{\"sample_rate\": 1.0}]","service":"compiled-in example","version":"v1.2.0"}
