### PR TITLE
Improve environment variable consistency between C++ tracer and other datadog tracers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,8 @@
 cc_library(
     name = "dd_opentracing_cpp",
     srcs = [
+        "src/bool.h",
+        "src/bool.cpp",
         "src/clock.h",
         "src/encoder.cpp",
         "src/encoder.h",

--- a/include/datadog/version.h
+++ b/include/datadog/version.h
@@ -6,7 +6,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.2.0";
+const std::string tracer_version = "v1.2.1";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version

--- a/src/bool.cpp
+++ b/src/bool.cpp
@@ -1,0 +1,27 @@
+#include <unordered_map>
+
+namespace datadog {
+namespace opentracing {
+
+namespace {
+std::unordered_map<std::string, bool> conversions{
+    {"1", true},  {"t", true},  {"T", true},  {"true", true},   {"TRUE", true},   {"True", true},
+    {"0", false}, {"f", false}, {"F", false}, {"false", false}, {"FALSE", false}, {"False", false},
+};
+}  // namespace
+
+bool stob(const std::string& str, bool fallback) {
+  if (str.empty()) {
+    return fallback;
+  }
+  auto result = conversions.find(str);
+  if (result == conversions.end()) {
+    return fallback;
+  }
+  return result->second;
+}
+
+bool isbool(const std::string& str) { return conversions.find(str) != conversions.end(); }
+
+}  // namespace opentracing
+}  // namespace datadog

--- a/src/bool.h
+++ b/src/bool.h
@@ -1,0 +1,13 @@
+#ifndef DD_OPENTRACING_BOOL_H
+#define DD_OPENTRACING_BOOL_H
+
+namespace datadog {
+namespace opentracing {
+
+bool stob(const std::string& str, bool fallback);
+bool isbool(const std::string& str);
+
+}  // namespace opentracing
+}  // namespace datadog
+
+#endif  // DD_OPENTRACING_BOOL_H

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -106,7 +106,9 @@ void WritingSpanBuffer::unbufferAndWriteTrace(uint64_t trace_id) {
     return;
   }
   auto& trace = trace_iter->second;
-  writer_->write(std::move(trace.finished_spans));
+  if (options_.enabled) {
+    writer_->write(std::move(trace.finished_spans));
+  }
   traces_.erase(trace_iter);
 }
 

--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -48,6 +48,7 @@ class SpanBuffer {
 };
 
 struct WritingSpanBufferOptions {
+  bool enabled = true;
   std::string hostname;
   double analytics_rate = std::nan("");
 };

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <random>
 
+#include "bool.h"
 #include "tracer.h"
 
 namespace ot = opentracing;
@@ -47,7 +48,7 @@ namespace {
 
 bool isEnabled() {
   auto enabled = std::getenv("DD_TRACE_ENABLED");
-  if (enabled != nullptr && std::string(enabled) == "false") {
+  if (enabled != nullptr && !stob(enabled, true)) {
     return false;
   }
   return true;

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -44,6 +44,15 @@ uint64_t getId() {
 }
 
 namespace {
+
+bool isEnabled() {
+  auto enabled = std::getenv("DD_TRACE_ENABLED");
+  if (enabled != nullptr && std::string(enabled) == "false") {
+    return false;
+  }
+  return true;
+}
+
 std::string reportingHostname(TracerOptions options) {
   // This returns the machine name when the tracer has been configured
   // to report hostnames.
@@ -228,7 +237,7 @@ Tracer::Tracer(TracerOptions options, std::shared_ptr<Writer> &writer,
   startupLog(options);
   buffer_ = std::make_shared<WritingSpanBuffer>(
       writer, sampler,
-      WritingSpanBufferOptions{reportingHostname(options), analyticsRate(options)});
+      WritingSpanBufferOptions{isEnabled(), reportingHostname(options), analyticsRate(options)});
 }
 
 std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation_name,

--- a/src/tracer_options.h
+++ b/src/tracer_options.h
@@ -9,6 +9,7 @@ namespace ot = opentracing;
 namespace datadog {
 namespace opentracing {
 
+// TODO(cgilmour): clean this up, since it's not really used generically.
 template <class Iterable>
 ot::expected<std::set<PropagationStyle>> asPropagationStyle(Iterable styles) {
   std::set<PropagationStyle> propagation_styles;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -109,6 +109,8 @@ struct MockBuffer : public WritingSpanBuffer {
 
   PendingTrace& traces(uint64_t id) { return traces_[id]; };
 
+  void setEnabled(bool enabled) { options_.enabled = enabled; };
+
   void setHostname(std::string hostname) { options_.hostname = hostname; };
 
   void setAnalyticsRate(double rate) { options_.analytics_rate = rate; };


### PR DESCRIPTION
Adds DD_TRACE_ENABLED that can be set to false. When set to false, the traces will still be generated and propagated as usual, but not sent to the agent.
Add bool parsing functions to clean up places that relied heavily on comparing strings to `true`, `false`, `1`, `0` etc.
Fix parsing of DD_PROPAGATION_STYLE variables, so that it allows comma-separated values instead of only space-separated.
Add bool parsing functions to clean up places that relied heavily on comparing strings to `true`, `false`, `1`, `0` etc.

Some opportunities to refactor code or add new tests were ignored for now to keep this fairly minimal.