### PR TITLE
doc: clarify how to use env vars in nginx

### DIFF
--- a/examples/nginx-tracing/dd-config.json
+++ b/examples/nginx-tracing/dd-config.json
@@ -1,6 +1,5 @@
 {
   "service": "nginx",
   "operation_name_override": "nginx.handle",
-  "agent_host": "dd-agent",
   "agent_port": 8126
 }

--- a/examples/nginx-tracing/docker-compose.yml
+++ b/examples/nginx-tracing/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - './index.html:/usr/share/nginx/html/index.html:ro'
     ports:
       - "8080:80"
+    environment:
+      DD_AGENT_HOST: dd-agent
+
   dd-agent:
     container_name: dd-agent
     volumes:

--- a/examples/nginx-tracing/nginx.conf
+++ b/examples/nginx-tracing/nginx.conf
@@ -4,6 +4,11 @@ events {
     worker_connections  1024;
 }
 
+# Note: This is important if you are going to use env variables for configuration.
+# Add all used envs here, if you miss one the worker process of nginx will have no access to it.
+# See: http://nginx.org/en/docs/ngx_core_module.html#env
+env DD_AGENT_HOST;
+
 http {
     opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
 


### PR DESCRIPTION
nginx does not inherit all env vars from the main process to its worker.
You must use the `env` keyword to specify which env should be passed.

If this part is omitted, the plugin is loaded in the worker process
without envs and thus will fallback to the default values and may not
work.

It happened to me and it was fairly hard to debug. 😅 