### PR TITLE
Fix error building with clang compilers

### DIFF
--- a/src/bool.cpp
+++ b/src/bool.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include <unordered_map>
 
 namespace datadog {


### PR DESCRIPTION
Some versions of clang report an error `error: implicit instantiation of
undefined template` (macos and envoy ci).
I haven't figured out the exact compiler and options though - no error
using clang from LLVM repos. That mystery can be figured out later.