### PR TITLE
Initial support for Windows / MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,14 @@ find_package(Sanitizers)
 # Code
 install(DIRECTORY include/datadog DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 file(GLOB DD_OPENTRACING_SOURCES "src/*.cpp")
-add_compile_options(-Wall -Wextra -Werror -Wnon-virtual-dtor -Woverloaded-virtual -Wold-style-cast -std=c++14)
+message(STATUS "Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
+if((CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  add_compile_options(-Wall -Wextra -Werror -Wnon-virtual-dtor -Woverloaded-virtual -Wold-style-cast -std=c++14)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  add_compile_options(/W3)
+else()
+  message(FATAL_ERROR "Unknown compiler ${CMAKE_CXX_COMPILER_ID}")
+endif()
 
 # Outputs
 set(DATADOG_LINK_LIBRARIES ${OPENTRACING_LIB} ${CURL_LIBRARIES} ${ZLIB_LIBRARIES} Threads::Threads)
@@ -59,7 +66,7 @@ if(BUILD_SHARED)
   add_sanitizers(dd_opentracing)
   target_link_libraries(dd_opentracing ${DATADOG_LINK_LIBRARIES})
   set_target_properties(dd_opentracing PROPERTIES SOVERSION ${SOVERSION})
-
+  target_compile_definitions(dd_opentracing PRIVATE DD_OPENTRACING_SHARED)
   install(TARGETS dd_opentracing
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -70,6 +77,7 @@ if(BUILD_STATIC)
   add_library(dd_opentracing-static STATIC ${DD_OPENTRACING_SOURCES})
   add_sanitizers(dd_opentracing-static)
   set_target_properties(dd_opentracing-static PROPERTIES OUTPUT_NAME dd_opentracing POSITION_INDEPENDENT_CODE ON)
+  target_compile_definitions(dd_opentracing PRIVATE DD_OPENTRACING_STATIC)
   install(TARGETS dd_opentracing-static
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For some quick-start examples, see the [examples](examples/) folder.
 
 Before considering contributions to the project, please take a moment to read our brief [contribution guidelines](CONTRIBUTING.md).
 
-## Build and Test
+## Build and Test (Linux and macOS)
 
 ### Dependencies
 
@@ -61,6 +61,39 @@ Additional libraries are installed via a script.
     ```
 
 If you want [sanitizers](https://github.com/google/sanitizers) to be enabled, then add either the `-DSANITIZE_THREAD=ON -DSANITIZE_UNDEFINED=ON` or `-DSANITIZE_ADDRESS=ON` flags to cmake, running the tests will now also check with the sanitizers.
+
+### Build (Windows)
+
+**NOTE**: This is currently Early Access, and issues should be reported only via GitHub Issues. Installation steps are likely to change based on user feedback and becoming available via Vcpkg.
+
+### Dependencies
+
+Building this project requires the following tools installed:
+
+- Visual Studio 2019 with "Desktop development for C++" installed
+- Vcpkg
+- Git
+
+### Build Steps
+
+The commands below should be executed in an `x64 Native Tools Command Prompt` shell.
+
+- Clone the repository
+    ```sh
+    cd %HOMEPATH%
+    git clone https://github.com/DataDog/dd-opentracing-cpp
+    ```
+- Generate build files using `cmake`
+    ```bat
+    cd dd-opentracing-cpp
+    mkdir .build
+    cd .build
+    cmake -DCMAKE_TOOLCHAIN_FILE=%HOMEPATH%\vcpkg\scripts\buildsystems\vcpkg.cmake ..
+    ```
+- Run the build
+    ```bat
+    cmake --build . -- -p:Configuration=RelWithDebInfo
+    ```
 
 ### Integration tests
 

--- a/examples/cpp-tracing/compiled-in/tracer_example.cpp
+++ b/examples/cpp-tracing/compiled-in/tracer_example.cpp
@@ -1,14 +1,16 @@
 #include <datadog/opentracing.h>
+#include <datadog/tags.h>
 #include <iostream>
 #include <string>
 
 int main(int argc, char* argv[]) {
-  datadog::opentracing::TracerOptions tracer_options{"dd-agent", 8126, "compiled-in example"};
+  datadog::opentracing::TracerOptions tracer_options{"localhost", 8126, "compiled-in example"};
   auto tracer = datadog::opentracing::makeTracer(tracer_options);
 
   // Create some spans.
   {
     auto span_a = tracer->StartSpan("A");
+    span_a->SetTag(datadog::tags::environment, "production");
     span_a->SetTag("tag", 123);
     auto span_b = tracer->StartSpan("B", {opentracing::ChildOf(&span_a->context())});
     span_b->SetTag("tag", "value");

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -1,6 +1,21 @@
 #ifndef DD_INCLUDE_OPENTRACING_TRACER_H
 #define DD_INCLUDE_OPENTRACING_TRACER_H
 
+#ifdef _MSC_VER
+#ifndef DD_OPENTRACING_STATIC
+// dllexport/dllimport declspecs need to be applied when building a DLL
+#ifdef DD_OPENTRACING_SHARED
+#define DD_OPENTRACING_API __declspec(dllexport)
+#else  // DD_OPENTRACING_SHARED
+#define DD_OPENTRACING_API __declspec(dllimport)
+#endif  // DD_OPENTRACING_SHARED
+#else   // DD_OPENTRACING_STATIC
+#define DD_OPENTRACING_API
+#endif  // DD_OPENTRACING_STATIC
+#else   // _MSC_VER
+#define DD_OPENTRACING_API
+#endif  // _MSC_VER
+
 #include <opentracing/tracer.h>
 
 #include <cmath>
@@ -140,7 +155,7 @@ class TraceEncoder {
 
 // makeTracer returns an opentracing::Tracer that submits traces to the Datadog Agent.
 // This should be used when control over the HTTP requests to the Datadog Agent is not required.
-std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions& options);
+DD_OPENTRACING_API std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions& options);
 // makeTracerAndEncoder initializes an opentracing::Tracer and provides an encoder
 // to use when submitting traces to the Datadog Agent.
 // This should be used in applications that need to also control the HTTP requests to the Datadog

--- a/src/sample.h
+++ b/src/sample.h
@@ -1,6 +1,12 @@
 #ifndef DD_OPENTRACING_SAMPLE_H
 #define DD_OPENTRACING_SAMPLE_H
 
+#ifdef _MSC_VER
+// When compiling with MSVC, std::numeric_limits::max is confused the the max macro,
+// and causes compilation errors.
+#undef max
+#endif
+
 #include <datadog/opentracing.h>
 #include <opentracing/tracer.h>
 #include <iostream>

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -2,9 +2,15 @@
 #include <datadog/tags.h>
 #include <errno.h>
 #include <opentracing/ext/tags.h>
-#include <pthread.h>
 #include <sys/stat.h>
+
+#ifdef _MSC_VER
+#include <winsock.h>
+#else
+#include <pthread.h>
 #include <unistd.h>
+#endif
+
 #include <fstream>
 #include <random>
 
@@ -24,7 +30,14 @@ namespace opentracing {
 namespace {
 class TlsRandomNumberGenerator {
  public:
-  TlsRandomNumberGenerator() { pthread_atfork(nullptr, nullptr, onFork); }
+  TlsRandomNumberGenerator() {
+#ifdef _MSC_VER
+// When compiling with MSVC, pthreads are not used.
+// TODO: investigate equivalent of pthread_atfork for MSVC
+#else
+    pthread_atfork(nullptr, nullptr, onFork);
+#endif
+  }
 
   static std::mt19937_64 &generator() { return random_number_generator_; }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -63,6 +63,10 @@ CURLcode CurlHandle::setopt(CURLoption key, long value) {
   return curl_easy_setopt(handle_, key, value);
 }
 
+CURLcode CurlHandle::setopt(CURLoption key, size_t value) {
+  return curl_easy_setopt(handle_, key, value);
+}
+
 void CurlHandle::setHeaders(std::map<std::string, std::string> headers) {
   for (auto& header : headers) {
     headers_[header.first] = header.second;  // Overwrite.

--- a/src/transport.h
+++ b/src/transport.h
@@ -16,6 +16,7 @@ class Handle {
   virtual ~Handle() {}
   virtual CURLcode setopt(CURLoption key, const char* value) = 0;
   virtual CURLcode setopt(CURLoption key, long value) = 0;
+  virtual CURLcode setopt(CURLoption key, size_t value) = 0;
   virtual void setHeaders(std::map<std::string, std::string> headers) = 0;
   virtual CURLcode perform() = 0;
   virtual std::string getError() = 0;
@@ -30,6 +31,7 @@ class CurlHandle : public Handle {
   ~CurlHandle() override;
   CURLcode setopt(CURLoption key, const char* value) override;
   CURLcode setopt(CURLoption key, long value) override;
+  CURLcode setopt(CURLoption key, size_t value) override;
   void setHeaders(std::map<std::string, std::string> headers) override;
   CURLcode perform() override;
   std::string getError() override;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -229,6 +229,14 @@ struct MockHandle : public Handle {
     return rcode;
   }
 
+  CURLcode setopt(CURLoption key, size_t value) override {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (rcode == CURLE_OK) {
+      options[key] = std::to_string(value);
+    }
+    return rcode;
+  }
+
   void setHeaders(std::map<std::string, std::string> headers_) override {
     for (auto& header : headers_) {
       headers[header.first] = header.second;  // Overwrite.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "dd-opentracing-cpp",
+  "version-string": "1.2.1",
+  "port-version": 0,
+  "homepage": "https://github.com/DataDog/dd-opentracing-cpp",
+  "description": "Datadog OpenTracing C++ Client",
+  "dependencies": [
+    "zlib",
+    "msgpack",
+    "curl",
+    "opentracing"
+  ]
+}


### PR DESCRIPTION
This adds support for building the C++ tracer on Windows using Visual Studio 2019.
Older versions may work but have not been tested.

It has been tested by manually building and running the tracer_example and confirming traces are reported and appear in the UI.
More work will be required to cover building and running the tracer's suite of tests, CI integration and other details related to the Windows ecosystem.

Fixes #134