### PR TITLE
Fix duplicate env entries in example nginx config

### DIFF
--- a/examples/nginx-tracing/nginx.conf
+++ b/examples/nginx-tracing/nginx.conf
@@ -1,4 +1,6 @@
 # Pass-through environment variables used by the datadog tracing plugin
+# Note: This is important if you are going to use env variables for configuration.
+# See: http://nginx.org/en/docs/ngx_core_module.html#env
 env DD_AGENT_HOST;
 env DD_ENV;
 
@@ -7,11 +9,6 @@ load_module modules/ngx_http_opentracing_module.so;
 events {
     worker_connections  1024;
 }
-
-# Note: This is important if you are going to use env variables for configuration.
-# Add all used envs here, if you miss one the worker process of nginx will have no access to it.
-# See: http://nginx.org/en/docs/ngx_core_module.html#env
-env DD_AGENT_HOST;
 
 http {
     opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;


### PR DESCRIPTION
Something I should have noticed while merging other PRs. Thanks @rmangi for pointing it out