### PR TITLE
Remove second setting of environment variables for traced-nginx

### DIFF
--- a/examples/nginx-tracing/docker-compose.yml
+++ b/examples/nginx-tracing/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - './index.html:/usr/share/nginx/html/index.html:ro'
     ports:
       - "8080:80"
-    environment:
-      DD_AGENT_HOST: dd-agent
 
   dd-agent:
     volumes:


### PR DESCRIPTION
The second setting of environment for traced-nginx was overriding the first, which can be confusing when testing things and makes no sense to have.