### PR TITLE
update versions of dependencies in integration test

### DIFF
--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -1,7 +1,7 @@
 # Creates an image with nginx and the Datadog OpenTracing nginx module installed.
 # Runs a simple integration test.
-ARG NGINX_VERSION=1.14.0
-ARG OPENTRACING_NGINX_VERSION=0.8.0
+ARG NGINX_VERSION=1.14.2
+ARG OPENTRACING_NGINX_VERSION=0.16.0
 
 # The nginx testbed. Build this image first since we don't want it rebuilt if just the code changes.
 FROM ubuntu:18.04 as nginx-testbed


### PR DESCRIPTION
When I ran `run_integration_tests_local.sh`, it would fail with an HTTP 404 for the release artifact whose name is constructed [here][1].  I looked around for a similarly named release, and then updated the variables in the `Dockerfile`.  I don't know what consequences this might have, but "it works now."  I also verified that `sudo /usr/local/bin/circleci local execute --job=integration_test_nginx` succeeds (the `sudo` needed on my system is I think an artifact of my use of rootless docker and circleci's use of `/var/run/docker.sock`).

Let's see if the CI comes up with anything fishy, and let me know if changing these versions is unkosher.

[1]: https://github.com/DataDog/dd-opentracing-cpp/blob/68dba8d27d5773a6603b7f2fbfef0cd877907930/test/integration/nginx/Dockerfile#L30