### PR TITLE
Catch runtime errors when creating `AgentWriter`.

### DIFF
--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -149,6 +149,9 @@ ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
   return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};
 } catch (const std::bad_alloc &) {
   return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
+} catch (const std::runtime_error &e) {
+  error_message = e.what();
+  return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));
 }
 
 // Make sure we generate code for a Tracer-producing factory.

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -55,6 +55,20 @@ TEST_CASE("writer") {
     REQUIRE(handle->options == test_case.expected_opts);
   }
 
+  SECTION("rejects unsupported url schemes") {
+    std::atomic<bool> handle_destructed{false};
+    std::unique_ptr<MockHandle> handle_ptr{new MockHandle{&handle_destructed}};
+    auto sampler = std::make_shared<RulesSampler>();
+    CHECK_THROWS(AgentWriter{std::move(handle_ptr),
+                             std::chrono::seconds(1),
+                             100,
+                             {},
+                             "localhost",
+                             1234,
+                             "gopher://hostname:1234/v0.4/traces",
+                             sampler});
+  }
+
   std::atomic<bool> handle_destructed{false};
   std::unique_ptr<MockHandle> handle_ptr{new MockHandle{&handle_destructed}};
   MockHandle* handle = handle_ptr.get();

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -201,6 +201,21 @@ TEST_CASE("tracer factory") {
     }
   }
 
+  SECTION("handles unsupported schemes") {
+    std::string input{R"(
+      {
+        "agent_url": "gopher://localhost:1234/path",
+        "service": "my-service"
+      }
+    )"};  // unsupported url scheme
+
+    std::string error = "";
+    auto result = factory.MakeTracer(input.c_str(), error);
+    REQUIRE(!result);
+    CHECK(result.error() == std::make_error_condition(std::errc::invalid_argument));
+    CHECK(error == "Unable to set agent URL: unknown url scheme: gopher://localhost:1234/path");
+  }
+
   SECTION("injected environment variables") {
     SECTION("DD_ENV overrides default") {
       ::setenv("DD_ENV", "injected-env", 0);


### PR DESCRIPTION
Catch exceptions thrown in the constructor of `AgentWriter` to avoid crashes when dynamically loading the library with unsupported URLs.

In some cases, the `AgentWriter` throws in the constructor (unsupported URL schemes and failed calls into CURL). Those exceptions aren't caught in the `MakeTracer` function which is marked as `noexcept` and therefore the application is terminated.

Note: Other invalid URLs are happily accepted by the tracer and result in just logged errors when CURL tries to ingest the traces.

Background: I noticed that in nginx-ingress controller. Result of configuring an unsupported URL scheme before the change:
```
ingress-nginx-controller-7456599f48-r6lbk controller Error: signal: aborted (core dumped)
ingress-nginx-controller-7456599f48-r6lbk controller terminate called without an active exception
```
and after:
```
ingress-nginx-controller-5bd9d99b5-8bncf controller nginx: [error] Failed to construct tracer: Unable to set agent URL: unknown url scheme: invalid_http://apm.datadog.svc.cluster.local
ingress-nginx-controller-5bd9d99b5-8bncf controller nginx: configuration file /tmp/nginx-cfg058182832 test failed
```
