### PR TITLE
workaround for apt-get update failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run:
           name: Tools required to build code and dependencies
           command: |
-            apt-get update
+            apt-get --allow-releaseinfo-change update
             DEBIAN_FRONTEND=noninteractive apt-get -y install git cmake g++-7
       - checkout
       - run:


### PR DESCRIPTION
The name of this branch has a typo in it.

This change to the CI configuration aims to address the following error: https://app.circleci.com/pipelines/github/DataDog/dd-opentracing-cpp/186/workflows/a3c5b45b-1e6b-40dc-b4ab-8a1266042559/jobs/3303

The package sources used by the integration test used to be labeled as "stable," but now they're labeled as "oldstable" (maybe since bullseye landed).  `apt-get update` doesn't like this and requires a user to confirm the change, somehow.  Google says that I can bypass this by adding the `--allow-releaseinfo-change` option to `apt-get`.

I wasn't able to test this locally, since `circle-ci`'s local runner doesn't work with my kernel's version of cgroup.

update: Hey, it succeeded in CI :D