### PR TITLE
Add a nightly build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,3 +169,13 @@ workflows:
           <<: *run_on_release_tag
           requires:
             - build
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build


### PR DESCRIPTION
Add a nightly build job in CircleCI (a requirements to do cross-components testing with other components).