### PR TITLE
Fix mixed log using string concat

### DIFF
--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -117,20 +117,22 @@ struct TracerOptions {
   // A logging function that is called by the tracer when noteworthy events occur.
   // The default value uses std::cerr, and applications can inject their own logging function.
   LogFunc log_func = [](LogLevel level, ot::string_view message) {
+    std::string level_str;
     switch (level) {
       case LogLevel::debug:
-        std::cerr << "debug: " << message << std::endl;
+        level_str = "debug";
         break;
       case LogLevel::info:
-        std::cerr << "info: " << message << std::endl;
+        level_str = "info";
         break;
       case LogLevel::error:
-        std::cerr << "error: " << message << std::endl;
+        level_str = "error";
         break;
       default:
-        std::cerr << "<unknown level>: " << message << std::endl;
+        level_str = "<unknown level>";
         break;
     }
+    std::cerr << level_str + ": " + message.data() + "\n";
   };
 };
 


### PR DESCRIPTION
(Should) fix https://github.com/DataDog/dd-opentracing-cpp/issues/195.

I did not test it yet this version where we had the issues but it would be nice to check that before merging it, unless reviewers of this are already confident it will do the trick to fix the issue mentioned above.

Concatenation with "+" may not be the most performant thing but anyway this default logging function is very rarely used. I only saw the log in #195 using this format.

Also, are we ok that the log message will still be flushed to `stderr` correctly, even if it's not using `std::endl`?

Finally, I'm not sure to understand why the "build" step of CI is failing, but it also fails on other recent PR :thinking: 

