### PR TITLE
Fixes to make CI happy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
   integration_test_nginx:
     working_directory: ~/dd-opentracing-cpp
     docker:
-      - image: opentracing/nginx-opentracing:0.16.0
+      - image: opentracing/nginx-opentracing:0.20.0
     environment:
       CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
       CFLAGS: -march=x86-64 -fPIC

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -5,7 +5,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.3.1";
+const std::string tracer_version = "v1.3.2";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version


### PR DESCRIPTION
The version needed bumping due to the release that shipped recently.
Also the nginx-opentracing image was reporting an error when performing `apt-get update`. Updated to a newer nginx-opentracing image.