### PR TITLE
add CI job to generate code coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ jobs:
             # <https://gcc.gnu.org/bugzilla//show_bug.cgi?id=101978>.
             CC=/usr/bin/clang-9 CXX=/usr/bin/clang++-9 cmake $CMAKE_ARGS ..
             make --jobs="$MAKE_JOB_COUNT"
-            printf 'Here is the value of RUN_ARGS: %s\n' "$RUN_ARGS"
             env $RUN_ARGS ctest --output-on-failure
 
   # Recent versions of the sanitizers have a bug where the combination of ubsan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
               getconf _NPROCESSORS_ONLN
               cat /sys/fs/cgroup/cpuset/cpuset.cpus
               cat /proc/self/cgroup
-              find /sys/fs/cgroup/cpuset/docker/
+              find /sys/fs/cgroup/cpuset
               uname -a
               cat /proc/meminfo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
   docker:
-    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_6
+    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
 
 jobs:
   build:
@@ -42,7 +42,7 @@ jobs:
             mkdir -p /tmp/build/
             cd .build
             cmake $CMAKE_ARGS ..
-            make
+            make --jobs=$(nproc)
             make install
             cp libdd_opentracing_plugin.so /tmp/build/libdd_opentracing_plugin.so
             cp libdd_opentracing.so /tmp/build/libdd_opentracing.so
@@ -74,7 +74,7 @@ jobs:
             mkdir -p .build
             cd .build
             cmake $CMAKE_ARGS ..
-            make
+            make --jobs=$(nproc)
             env $RUN_ARGS ctest --output-on-failure
 
   test_tsan:
@@ -117,7 +117,7 @@ jobs:
             mkdir -p /tmp/build/
             cd .build
             cmake $CMAKE_ARGS ..
-            make
+            make --jobs=$(nproc)
             make install
             cp libdd_opentracing_plugin.so /usr/local/lib/libdd_opentracing_plugin.so
       - run:
@@ -143,6 +143,29 @@ jobs:
             # Run the tests.
             bash -x ./nginx_integration_test.sh
 
+  test_coverage:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Build source dependencies
+          command: |
+            ./scripts/install_dependencies.sh
+      - run:
+          name: Build (with cmake) and test with coverage
+          command: |
+            rm -rf .build
+            scripts/run_coverage.sh
+            rm -rf /tmp/coverage
+            mkdir /tmp/coverage
+            tar czf /tmp/coverage/report.tar.gz coverage/report
+      - persist_to_workspace:
+          root: /tmp/
+          paths:
+            - coverage
+      - store_artifacts:
+          path: /tmp/coverage
+
 _workflow_filters:
   _version_tag: &version_tag
     # Allows semver or "test" tags, with any suffix.
@@ -166,6 +189,10 @@ workflows:
       - test_asan:
           <<: *run_on_release_tag
       - integration_test_nginx:
+          <<: *run_on_release_tag
+          requires:
+            - build
+      - test_coverage:
           <<: *run_on_release_tag
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 
-default-environment: &default-environment
+default_environment: &default_environment
     # The `resource_class` specified in the `defaults` implies a memory limit
     # and supposedly a CPU count limit.  However, either there is no actual CPU
     # count limit, or the limit cannot be determined from within the running
@@ -20,13 +20,13 @@ defaults: &defaults
   docker:
     - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
   resource_class: medium
-  environment: *default-environment
+  environment: *default_environment
 
 jobs:
   build:
     <<: *defaults
     environment:
-      <<: *default-environment
+      <<: *default_environment
       CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_STATIC=ON -DBUILD_SHARED=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
       CFLAGS: -march=x86-64 -fPIC
       CXXFLAGS: -march=x86-64 -fPIC
@@ -88,33 +88,58 @@ jobs:
       - run:
           name: Build and test
           command: |
+            set -x
             rm -rf .build
             mkdir -p .build
             cd .build
-            cmake $CMAKE_ARGS ..
+            # Build sanitized tests using clang instead of GCC.  There is an
+            # bug in a recent version of libstdc++ that causes thread sanitizer
+            # to interpret waits on a condition variable as a "double lock" of
+            # the involved mutex.  Until that is resolved, it's easiest to just
+            # build with clang, which uses libc++ instead of libstdc++. See
+            # <https://github.com/google/sanitizers/issues/1259>
+            # and
+            # <https://gcc.gnu.org/bugzilla//show_bug.cgi?id=101978>.
+            CC=/usr/bin/clang-9 CXX=/usr/bin/clang++-9 cmake $CMAKE_ARGS ..
             make --jobs="$MAKE_JOB_COUNT"
+            printf 'Here is the value of RUN_ARGS: %s\n' "$RUN_ARGS"
             env $RUN_ARGS ctest --output-on-failure
+
+  # Recent versions of the sanitizers have a bug where the combination of ubsan
+  # (the undefined behavior sanitizer) and tsan (the thread sanitizer) causes
+  # one to emit a false positive for the other.  See
+  # <https://github.com/google/sanitizers/issues/1106>.
+  # As a workaround, here we use ubsan by itself.  Previously it was run as
+  # part of `test_tsan`.
+  test_ubsan:
+    <<: *test_sanitizer_base
+    environment:
+      <<: *default_environment
+      CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_UNDEFINED=On
+      # Give it a blank value, or else it will default to "<nil>"
+      RUN_ARGS: ""
 
   test_tsan:
     <<: *test_sanitizer_base
     environment:
-      <<: *default-environment
-      CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_THREAD=On -DSANITIZE_UNDEFINED=On
+      <<: *default_environment
+      CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_THREAD=On
       RUN_ARGS: TSAN_OPTIONS=detect_deadlocks=1:second_deadlock_stack=1
 
   test_asan:
     <<: *test_sanitizer_base
     environment:
-      <<: *default-environment
+      <<: *default_environment
       CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_ADDRESS=On
-      RUN ARGS:
+      # Give it a blank value, or else it will default to "<nil>"
+      RUN_ARGS: ""
 
   integration_test_nginx:
     working_directory: ~/dd-opentracing-cpp
     docker:
       - image: opentracing/nginx-opentracing:0.20.0
     environment:
-      <<: *default-environment
+      <<: *default_environment
       CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
       CFLAGS: -march=x86-64 -fPIC
       CXXFLAGS: -march=x86-64 -fPIC
@@ -231,6 +256,10 @@ workflows:
           requires:
             - stat
       - test_asan:
+          <<: *run_on_release_tag
+          requires:
+            - stat
+      - test_ubsan:
           <<: *run_on_release_tag
           requires:
             - stat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
             command: |
               set -x
               nproc
+              getconf _NPROCESSORS_ONLN
               uname -a
               cat /proc/meminfo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
   docker:
     - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
+  resource_class: medium+
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ jobs:
               nproc
               getconf _NPROCESSORS_ONLN
               cat /sys/fs/cgroup/cpuset/cpuset.cpus
+              cat /proc/self/cgroup
               uname -a
               cat /proc/meminfo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ jobs:
               getconf _NPROCESSORS_ONLN
               cat /sys/fs/cgroup/cpuset/cpuset.cpus
               cat /proc/self/cgroup
+              cat /proc/cgroups
               find /sys/fs/cgroup/cpuset
               uname -a
               cat /proc/meminfo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ jobs:
               set -x
               nproc
               getconf _NPROCESSORS_ONLN
+              cat /sys/fs/cgroup/cpuset/cpuset.cpus
               uname -a
               cat /proc/meminfo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,21 @@ defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
   docker:
     - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
-  resource_class: medium+
+  resource_class: medium
+  environment:
+    # The `resource_class`, above, implies a memory limit and supposedly a CPU
+    # count limit.  However, either there is no actual CPU count limit, or the
+    # limit cannot be determined from within the running job.  Instead, the
+    # number of CPUs on the host machine is all we can see.  This means that a
+    # command like `make --jobs=$(nproc)` is likely to run out of memory,
+    # because while the `resource_class` says it has 2 CPUs, `nproc` will
+    # report something like 36.  `make` will then spawn a bunch of processes,
+    # and the job will run out of memory.
+    # So, here we hard-code the number of CPUs supposedly offered by the
+    # `resource_class`.  For information about the `resource_class` values,
+    # see:
+    # https://circleci.com/docs/2.0/configuration-reference/
+    MAKE_JOB_COUNT: 2
 
 jobs:
   build:
@@ -43,7 +57,7 @@ jobs:
             mkdir -p /tmp/build/
             cd .build
             cmake $CMAKE_ARGS ..
-            make --jobs=$(nproc)
+            make --jobs="$MAKE_JOB_COUNT"
             make install
             cp libdd_opentracing_plugin.so /tmp/build/libdd_opentracing_plugin.so
             cp libdd_opentracing.so /tmp/build/libdd_opentracing.so
@@ -75,7 +89,7 @@ jobs:
             mkdir -p .build
             cd .build
             cmake $CMAKE_ARGS ..
-            make --jobs=$(nproc)
+            make --jobs="$MAKE_JOB_COUNT"
             env $RUN_ARGS ctest --output-on-failure
 
   test_tsan:
@@ -118,7 +132,7 @@ jobs:
             mkdir -p /tmp/build/
             cd .build
             cmake $CMAKE_ARGS ..
-            make --jobs=$(nproc)
+            make --jobs="$MAKE_JOB_COUNT"
             make install
             cp libdd_opentracing_plugin.so /usr/local/lib/libdd_opentracing_plugin.so
       - run:
@@ -174,6 +188,7 @@ jobs:
             name: Print information about the execution environment
             command: |
               set -x
+              env | sort
               nproc
               getconf _NPROCESSORS_ONLN
               cat /sys/fs/cgroup/cpuset/cpuset.cpus

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
               cat /sys/fs/cgroup/cpuset/cpuset.cpus
               cat /proc/self/cgroup
               cat /proc/cgroups
-              find /sys/fs/cgroup/cpuset
+              find /sys/fs/cgroup
               uname -a
               cat /proc/meminfo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,17 @@ jobs:
             - coverage
       - store_artifacts:
           path: /tmp/coverage
+            
+  stat:
+      <<: *defaults
+      steps:
+        - run:
+            name: Print information about the execution environment
+            command: |
+              set -x
+              nproc
+              uname -a
+              cat /proc/meminfo
 
 _workflow_filters:
   _version_tag: &version_tag
@@ -183,12 +194,20 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
+      - stat:
+          <<: *run_on_release_tag
       - build:
           <<: *run_on_release_tag
+          requires:
+            - stat
       - test_tsan:
           <<: *run_on_release_tag
+          requires:
+            - stat
       - test_asan:
           <<: *run_on_release_tag
+          requires:
+            - stat
       - integration_test_nginx:
           <<: *run_on_release_tag
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ jobs:
               getconf _NPROCESSORS_ONLN
               cat /sys/fs/cgroup/cpuset/cpuset.cpus
               cat /proc/self/cgroup
+              find /sys/fs/cgroup/cpuset/docker/
               uname -a
               cat /proc/meminfo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,15 +218,14 @@ jobs:
             name: Print information about the execution environment
             command: |
               set -x
-              env | sort
               nproc
               getconf _NPROCESSORS_ONLN
               cat /sys/fs/cgroup/cpuset/cpuset.cpus
               cat /proc/self/cgroup
               cat /proc/cgroups
-              find /sys/fs/cgroup
               uname -a
               cat /proc/meminfo
+              cat /proc/cpuinfo | sed '/^$/q'
 
 _workflow_filters:
   _version_tag: &version_tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,32 @@
 version: 2
 
-defaults: &defaults
-  working_directory: ~/dd-opentracing-cpp
-  docker:
-    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
-  resource_class: medium
-  environment:
-    # The `resource_class`, above, implies a memory limit and supposedly a CPU
-    # count limit.  However, either there is no actual CPU count limit, or the
-    # limit cannot be determined from within the running job.  Instead, the
-    # number of CPUs on the host machine is all we can see.  This means that a
-    # command like `make --jobs=$(nproc)` is likely to run out of memory,
-    # because while the `resource_class` says it has 2 CPUs, `nproc` will
-    # report something like 36.  `make` will then spawn a bunch of processes,
-    # and the job will run out of memory.
+default-environment: &default-environment
+    # The `resource_class` specified in the `defaults` implies a memory limit
+    # and supposedly a CPU count limit.  However, either there is no actual CPU
+    # count limit, or the limit cannot be determined from within the running
+    # job.  Instead, the number of CPUs on the host machine is all we can see.
+    # This means that a command like `make --jobs=$(nproc)` is likely to run
+    # out of memory, because while the `resource_class` says it has 2 CPUs,
+    # `nproc` will report something like 36.  `make` will then spawn a bunch of
+    # processes, and the job will run out of memory.
     # So, here we hard-code the number of CPUs supposedly offered by the
     # `resource_class`.  For information about the `resource_class` values,
     # see:
     # https://circleci.com/docs/2.0/configuration-reference/
     MAKE_JOB_COUNT: 2
 
+defaults: &defaults
+  working_directory: ~/dd-opentracing-cpp
+  docker:
+    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
+  resource_class: medium
+  environment: *default-environment
+
 jobs:
   build:
     <<: *defaults
     environment:
+      <<: *default-environment
       CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_STATIC=ON -DBUILD_SHARED=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
       CFLAGS: -march=x86-64 -fPIC
       CXXFLAGS: -march=x86-64 -fPIC
@@ -95,12 +98,14 @@ jobs:
   test_tsan:
     <<: *test_sanitizer_base
     environment:
+      <<: *default-environment
       CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_THREAD=On -DSANITIZE_UNDEFINED=On
       RUN_ARGS: TSAN_OPTIONS=detect_deadlocks=1:second_deadlock_stack=1
 
   test_asan:
     <<: *test_sanitizer_base
     environment:
+      <<: *default-environment
       CMAKE_ARGS: -DBUILD_TESTING=ON -DSANITIZE_ADDRESS=On
       RUN ARGS:
 
@@ -109,6 +114,7 @@ jobs:
     docker:
       - image: opentracing/nginx-opentracing:0.20.0
     environment:
+      <<: *default-environment
       CMAKE_ARGS: -DBUILD_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
       CFLAGS: -march=x86-64 -fPIC
       CXXFLAGS: -march=x86-64 -fPIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 
 project(dd-opentracing-cpp)
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -11,6 +11,8 @@ CURL_VERSION=${CURL_VERSION:-7.70.0}
 MSGPACK_VERSION=${MSGPACK_VERSION:-3.2.1}
 ZLIB_VERSION=${ZLIB_VERSION:-1.2.11}
 
+MAKE_JOB_COUNT=${MAKE_JOB_COUNT:-$(nproc)}
+
 # Just report versions and exit.
 if [[ "$1" == "versions" ]]; then
 	echo "opentracing:$OPENTRACING_VERSION"
@@ -58,7 +60,7 @@ if [ "$BUILD_OPENTRACING" -eq "1" ]; then
         -DBUILD_TESTING=OFF \
         -DBUILD_MOCKTRACER=OFF \
         ..
-  make
+  make --jobs="$MAKE_JOB_COUNT"
   make install
   cd ../..
   rm -r "opentracing-cpp-${OPENTRACING_VERSION}/"
@@ -72,7 +74,7 @@ if [ "$BUILD_ZLIB" -eq "1" ]; then
   mkdir -p "zlib-${ZLIB_VERSION}"
   cd "zlib-${ZLIB_VERSION}"
   CFLAGS="$CFLAGS -fPIC" ./configure --prefix="$install_dir" --static
-  make && make install
+  make --jobs="$MAKE_JOB_COUNT" && make install
   cd ..
   rm -r "zlib-${ZLIB_VERSION}"
   rm "zlib-${ZLIB_VERSION}.tar.gz"
@@ -85,7 +87,7 @@ if [ "$BUILD_MSGPACK" -eq "1" ]; then
   mkdir -p "msgpack-${MSGPACK_VERSION}/.build"
   cd "msgpack-${MSGPACK_VERSION}/.build"
   cmake -DCMAKE_INSTALL_PREFIX="$install_dir" -DBUILD_SHARED_LIBS=OFF ..
-  make
+  make --jobs="$MAKE_JOB_COUNT"
   make install
   cd ../..
   rm -r "msgpack-${MSGPACK_VERSION}/"
@@ -115,7 +117,7 @@ if [ "$BUILD_CURL" -eq "1" ]; then
               --enable-shared=no \
               --enable-static=yes \
               --with-pic
-  make && make install
+  make --jobs="$MAKE_JOB_COUNT" && make install
   cd ..
   rm -r "curl-${CURL_VERSION}/"
   rm "curl-${CURL_VERSION}.tar.gz"

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -24,7 +24,7 @@ END_USAGE
 set -e
 
 cmake_flags=('-DBUILD_TESTING=ON')
-make_flags=("--jobs=$(nproc)")
+make_flags=("--jobs=${MAKE_JOB_COUNT:-$(nproc)}")
 ctest_flags=('--output-on-failure')
 
 # Parse command line options.

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -12,7 +12,6 @@ namespace opentracing {
 
 namespace {
 const std::string agent_protocol = "http://";
-const size_t max_queued_traces = 7000;
 // Retry sending traces to agent a couple of times. Any more than that and the agent won't accept
 // them.
 // write_period 1s + timeout 2s + (retry & timeout) 2.5s + (retry and timeout) 4.5s = 10s.
@@ -25,8 +24,8 @@ const long default_timeout_ms = 2000L;
 AgentWriter::AgentWriter(std::string host, uint32_t port, std::string url,
                          std::chrono::milliseconds write_period,
                          std::shared_ptr<RulesSampler> sampler)
-    : AgentWriter(std::unique_ptr<Handle>{new CurlHandle{}}, write_period, max_queued_traces,
-                  default_retry_periods, host, port, url, sampler) {}
+    : AgentWriter(std::unique_ptr<Handle>{new CurlHandle{}}, write_period,
+                  default_max_queued_traces, default_retry_periods, host, port, url, sampler) {}
 
 AgentWriter::AgentWriter(std::unique_ptr<Handle> handle, std::chrono::milliseconds write_period,
                          size_t max_queued_traces,

--- a/src/agent_writer.h
+++ b/src/agent_writer.h
@@ -45,6 +45,11 @@ class AgentWriter : public Writer {
   // Permanently stops writing Traces. Calls to write() and flush() will do nothing.
   void stop();
 
+  // Default value of `max_queued_traces` in the constructor overload without
+  // that parameter. This implementation detail is exposed for use in the unit
+  // test.
+  static const size_t default_max_queued_traces = 7000;
+
  private:
   // Initialises the curl handle. May throw a runtime_exception.
   void setUpHandle(std::unique_ptr<Handle> &handle, std::string host, uint32_t port,

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -3,10 +3,6 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
-#include "agent_writer.h"
-#include "tracer.h"
-#include "tracer_options.h"
-
 using json = nlohmann::json;
 
 namespace datadog {
@@ -110,52 +106,6 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
 
   return options;
 }
-
-// Accepts configuration in JSON format, with the following keys:
-// "service": Required. A string, the name of the service.
-// "agent_host": A string, defaults to localhost. Can also be set by the environment variable
-//     DD_AGENT_HOST
-// "agent_port": A number, defaults to 8126. "type": A string, defaults to web. Can also be set by
-//     the environment variable DD_TRACE_AGENT_PORT
-// "type": A string, defaults to web.
-// "environment": A string, defaults to "". The environment this trace belongs to.
-//     eg. "" (env:none), "staging", "prod". Can also be set by the environment variable
-//     DD_ENV
-// "sample_rate": A double, defaults to 1.0.
-// "operation_name_override": A string, if not empty it overrides the operation name (and the
-//     overridden operation name is recorded in the tag "operation").
-// "propagation_style_extract": A list of strings, each string is one of "Datadog", "B3". Defaults
-//     to ["Datadog"]. The type of headers to use to propagate distributed traces. Can also be set
-//     by the environment variable DD_PROPAGATION_STYLE_EXTRACT.
-// "propagation_style_inject": A list of strings, each string is one of "Datadog", "B3". Defaults
-//     to ["Datadog"]. The type of headers to use to receive distributed traces. Can also be set by
-//     the environment variable DD_PROPAGATION_STYLE_INJECT.
-//
-// Extra keys will be ignored.
-template <class TracerImpl>
-ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
-    const char *configuration, std::string &error_message) const noexcept try {
-  auto maybe_options = optionsFromConfig(configuration, error_message);
-  if (!maybe_options) {
-    return ot::make_unexpected(maybe_options.error());
-  }
-  TracerOptions options = maybe_options.value();
-
-  auto sampler = std::make_shared<RulesSampler>();
-  auto writer = std::shared_ptr<Writer>{
-      new AgentWriter(options.agent_host, options.agent_port, options.agent_url,
-                      std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
-
-  return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};
-} catch (const std::bad_alloc &) {
-  return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
-} catch (const std::runtime_error &e) {
-  error_message = e.what();
-  return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));
-}
-
-// Make sure we generate code for a Tracer-producing factory.
-template class TracerFactory<Tracer>;
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/tracer_factory.h
+++ b/src/tracer_factory.h
@@ -23,8 +23,8 @@ class TracerFactory : public ot::TracerFactory {
   // "service": Required. A string, the name of the service.
   // "agent_host": A string, defaults to localhost. Can also be set by the environment variable
   //     DD_AGENT_HOST
-  // "agent_port": A number, defaults to 8126. "type": A string, defaults to web. Can also be set by
-  //     the environment variable DD_TRACE_AGENT_PORT
+  // "agent_port": A number, defaults to 8126. "type": A string, defaults to web. Can also be set
+  //     by the environment variable DD_TRACE_AGENT_PORT
   // "type": A string, defaults to web.
   // "environment": A string, defaults to "". The environment this trace belongs to.
   //     eg. "" (env:none), "staging", "prod". Can also be set by the environment variable
@@ -32,12 +32,13 @@ class TracerFactory : public ot::TracerFactory {
   // "sample_rate": A double, defaults to 1.0.
   // "operation_name_override": A string, if not empty it overrides the operation name (and the
   //     overridden operation name is recorded in the tag "operation").
-  // "propagation_style_extract": A list of strings, each string is one of "Datadog", "B3". Defaults
-  //     to ["Datadog"]. The type of headers to use to propagate distributed traces. Can also be set
-  //     by the environment variable DD_PROPAGATION_STYLE_EXTRACT.
+  // "propagation_style_extract": A list of strings, each string is one of "Datadog", "B3".
+  //     Defaults to ["Datadog"]. The type of headers to use to propagate
+  //     distributed traces. Can also be set by the environment variable
+  //     DD_PROPAGATION_STYLE_EXTRACT.
   // "propagation_style_inject": A list of strings, each string is one of "Datadog", "B3". Defaults
-  //     to ["Datadog"]. The type of headers to use to receive distributed traces. Can also be set by
-  //     the environment variable DD_PROPAGATION_STYLE_INJECT.
+  //     to ["Datadog"]. The type of headers to use to receive distributed traces. Can also be set
+  //     by the environment variable DD_PROPAGATION_STYLE_INJECT.
   //
   // Extra keys will be ignored.
   ot::expected<std::shared_ptr<ot::Tracer>> MakeTracer(const char *configuration,

--- a/src/tracer_factory.h
+++ b/src/tracer_factory.h
@@ -4,6 +4,10 @@
 #include <datadog/opentracing.h>
 #include <opentracing/tracer_factory.h>
 
+#include "agent_writer.h"
+#include "tracer.h"
+#include "tracer_options.h"
+
 namespace ot = opentracing;
 
 namespace datadog {
@@ -15,10 +19,53 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
 template <class TracerImpl>
 class TracerFactory : public ot::TracerFactory {
  public:
+  // Accepts configuration in JSON format, with the following keys:
+  // "service": Required. A string, the name of the service.
+  // "agent_host": A string, defaults to localhost. Can also be set by the environment variable
+  //     DD_AGENT_HOST
+  // "agent_port": A number, defaults to 8126. "type": A string, defaults to web. Can also be set by
+  //     the environment variable DD_TRACE_AGENT_PORT
+  // "type": A string, defaults to web.
+  // "environment": A string, defaults to "". The environment this trace belongs to.
+  //     eg. "" (env:none), "staging", "prod". Can also be set by the environment variable
+  //     DD_ENV
+  // "sample_rate": A double, defaults to 1.0.
+  // "operation_name_override": A string, if not empty it overrides the operation name (and the
+  //     overridden operation name is recorded in the tag "operation").
+  // "propagation_style_extract": A list of strings, each string is one of "Datadog", "B3". Defaults
+  //     to ["Datadog"]. The type of headers to use to propagate distributed traces. Can also be set
+  //     by the environment variable DD_PROPAGATION_STYLE_EXTRACT.
+  // "propagation_style_inject": A list of strings, each string is one of "Datadog", "B3". Defaults
+  //     to ["Datadog"]. The type of headers to use to receive distributed traces. Can also be set by
+  //     the environment variable DD_PROPAGATION_STYLE_INJECT.
+  //
+  // Extra keys will be ignored.
   ot::expected<std::shared_ptr<ot::Tracer>> MakeTracer(const char *configuration,
                                                        std::string &error_message) const
       noexcept override;
 };
+
+template <class TracerImpl>
+ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
+    const char *configuration, std::string &error_message) const noexcept try {
+  auto maybe_options = optionsFromConfig(configuration, error_message);
+  if (!maybe_options) {
+    return ot::make_unexpected(maybe_options.error());
+  }
+  TracerOptions options = maybe_options.value();
+
+  auto sampler = std::make_shared<RulesSampler>();
+  auto writer = std::shared_ptr<Writer>{
+      new AgentWriter(options.agent_host, options.agent_port, options.agent_url,
+                      std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
+
+  return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};
+} catch (const std::bad_alloc &) {
+  return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
+} catch (const std::runtime_error &e) {
+  error_message = e.what();
+  return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));
+}
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -5,7 +5,6 @@
 #include <catch2/catch.hpp>
 #include <ctime>
 
-#include "../src/agent_writer.cpp"  // Otherwise the compiler won't generate AgentWriter for us.
 #include "mocks.h"
 using namespace datadog::opentracing;
 
@@ -390,6 +389,7 @@ TEST_CASE("flush") {
   std::unique_ptr<MockHandle> handle_ptr{new MockHandle{}};
   MockHandle* handle = handle_ptr.get();
   std::vector<std::chrono::milliseconds> retry_periods{std::chrono::seconds(60)};
+  const size_t max_queued_traces = AgentWriter::default_max_queued_traces;
   AgentWriter writer{std::move(handle_ptr),
                      std::chrono::seconds(3600),
                      max_queued_traces,

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -3,12 +3,10 @@
 #include "../src/tracer.h"
 #include "mocks.h"
 
-// Source file needed to ensure compilation of templated class TracerFactory<MockTracer>
 #include <datadog/tags.h>
 
 #include <catch2/catch.hpp>
 
-#include "../src/tracer_factory.cpp"
 using namespace datadog::opentracing;
 
 TEST_CASE("tracer factory") {

--- a/test/tracer_factory_test.cpp
+++ b/test/tracer_factory_test.cpp
@@ -1,11 +1,11 @@
 #include "../src/tracer_factory.h"
 
-#include "../src/tracer.h"
-#include "mocks.h"
-
 #include <datadog/tags.h>
 
 #include <catch2/catch.hpp>
+
+#include "../src/tracer.h"
+#include "mocks.h"
 
 using namespace datadog::opentracing;
 


### PR DESCRIPTION
This adds a job to CircleCI, `test_coverage`, that builds the library and its unit tests with coverage enabled, and then runs the tests, generates a coverage report website using `lcov`, and saves the tar'd gzip'd result as a build artifact.

This PR depends on changes to the build image in https://github.com/DataDog/docker-library/pull/74. I needed to add `lcov` and upgrade the version of `cmake` by using a more recent Ubuntu distribution. Before we can merge this PR, we must merge https://github.com/DataDog/docker-library/pull/74 and publish the new Docker image.

Update: The sanitized test jobs didn't like the newer version of Ubuntu. This pull request now includes various workarounds to:

- allow multiple concurrent `make` jobs
- prevent "\<nil\>" from appearing on `env` commands
- avoid a bug where ubsan accuses tsan of being out of line
- avoid a bug where tsan thinks `libstdc++` condition variables are double-locking mutexes.
- remove `#include ...cpp` from unit tests
- d̸e̴s̷c̸e̸n̴d̶ ̷n̴o̸w̸ i̴̼͖̥̼̕͝n̵͙̑t̷̯͍̤̠͑̒o̸̦͖̠̐̋̀̒ ̸̢̨̩͆͝t̸̡͍̙͐̑͑͜h̷̹̪͓̄͗e̷̡̙͎͍̐̃̿̚ ̵̳͇͘̚p̶̝͉̈͝į̶̛͇̻̺t̴͕̪̀͗ͅ ̴̢̡̘̤̕o̴̤͓̜͠f̶̧͈̺̯̌̓̐̊ ̴̜̿d̷͚̟͇̊͜e̵͖̦͑͂̇s̸̡͖̰̈͊̈́̀p̶͓̉̉̃ȁ̴̞̬͔̠͝i̸̧͔̘͋͆r̶͎͘ṱ̷̙͎̀͑h̵͉̬͕̞̱̤̓͝e̶̢̻̋̓̆̃̆͒ř̵̗̜̪̪̗͕̅͐é̴̥̮̘̰ ̵̜̝͚̔̀͊̈́̆̅i̷͈͖͉͑̿̈́̄̽s̷̳̱̈́͋̚ ̵͈̅̽͜n̷̢̼͎̪̭̿̓̓͌̕ǒ̴̼̠̮̼͚̇͘ ̸͕̜̞͂ḧ̶̰̼ò̴̩̼͚̃̊p̷͝ͅe̵̜̍̈́̈́͛͒̃ ̶̢̈́̊y̵̭̯͔̲̺͍̻̌ͅo̵̪͝ȕ̷̧̡͙̠̰͇͜r̴̼̖͉̈́͂̃̔̓̑̈ ̵͓̏̓f̵̨̜͔̝̞͖͔̏l̸̰̱͍̱̒͗̏e̸̢̞̮͎̟͓͚̅̽̈́̑͘̕͝ş̴͇̫̺͍̱͋̍͌̈̿͜h̶͚̺͚̺͕̗͇̲̿̑͌̾̍̔͠ ̷̬̜̆͑̋̏͋ẉ̶͎̬̎̋́̾î̵̡̡̞̹̥͎l̶̡͆̔͋̕͠ļ̶͎́̈͑͒͗ ̷̩̥̿̆͆̊̀͌͗͠f̷̧̲̳̠̭̞̯̈́̓̋͆̐͒̉͜͝e̸̼̝͈̥̎ͅͅę̵̡͔͍͓̓͑̈ḏ̸̡̱̭̪̰̖̀͛̂̾̇̉͜ ̸̩̖̾̈̇̅͛t̵̨̹̱͇̥̏h̵͈̻͙͕̊̀̂̍̀́̈́͝ȩ̶̨̨̗͉̣͕̹̈̑̑̃͌̀͠ ̵̳̲̓͛̂́į̵̫̯̈́͂͛̀͘ͅǹ̶͚͂͋͒̅̑̅͘f̴̛̟̱̺̦̥̤͍͒́̔͆́̊̕ĩ̵̗͌̀͛͒n̷̩̺̹̞̻̎̑ḯ̸̦̞͖͓̎̊́̑̄t̵͔̐̓ë̶͙͌̈́̇͗̄̽ ̶͍̙͖͋͂̏̀͑̒̊m̴̳̗̠̙̂̾͛͋͜͜ͅa̷̧͎̗̘̻̼̬̼̽͋̓͌̆w̷͇̦̹͌̈̆̐͂