### PR TITLE
use the Logger class wherever possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,22 +211,6 @@ jobs:
       - store_artifacts:
           path: /tmp/coverage
             
-  stat:
-      <<: *defaults
-      steps:
-        - run:
-            name: Print information about the execution environment
-            command: |
-              set -x
-              nproc
-              getconf _NPROCESSORS_ONLN
-              cat /sys/fs/cgroup/cpuset/cpuset.cpus
-              cat /proc/self/cgroup
-              cat /proc/cgroups
-              uname -a
-              cat /proc/meminfo
-              cat /proc/cpuinfo | sed '/^$/q'
-
 _workflow_filters:
   _version_tag: &version_tag
     # Allows semver or "test" tags, with any suffix.
@@ -243,24 +227,14 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - stat:
-          <<: *run_on_release_tag
       - build:
           <<: *run_on_release_tag
-          requires:
-            - stat
       - test_tsan:
           <<: *run_on_release_tag
-          requires:
-            - stat
       - test_asan:
           <<: *run_on_release_tag
-          requires:
-            - stat
       - test_ubsan:
           <<: *run_on_release_tag
-          requires:
-            - stat
       - integration_test_nginx:
           <<: *run_on_release_tag
           requires:

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -1,11 +1,11 @@
 #include "agent_writer.h"
 
+#include <sstream>
+
 #include "encoder.h"
 #include "sample.h"
 #include "span.h"
 #include "transport.h"
-
-#include <sstream>
 
 namespace datadog {
 namespace opentracing {
@@ -27,12 +27,14 @@ AgentWriter::AgentWriter(std::string host, uint32_t port, std::string url,
                          std::shared_ptr<const Logger> logger)
     // `CurlHandle` is defined in `transport.h`.
     : AgentWriter(std::unique_ptr<Handle>{new CurlHandle{logger}}, write_period,
-                  default_max_queued_traces, default_retry_periods, host, port, url, sampler, logger) {}
+                  default_max_queued_traces, default_retry_periods, host, port, url, sampler,
+                  logger) {}
 
 AgentWriter::AgentWriter(std::unique_ptr<Handle> handle, std::chrono::milliseconds write_period,
                          size_t max_queued_traces,
                          std::vector<std::chrono::milliseconds> retry_periods, std::string host,
-                         uint32_t port, std::string url, std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger)
+                         uint32_t port, std::string url, std::shared_ptr<RulesSampler> sampler,
+                         std::shared_ptr<const Logger> logger)
     : Writer(sampler, logger),
       write_period_(write_period),
       max_queued_traces_(max_queued_traces),
@@ -197,7 +199,8 @@ bool AgentWriter::retryFiniteOnFail(std::function<bool()> f) const {
 }
 
 bool AgentWriter::postTraces(std::unique_ptr<Handle> &handle,
-                             std::map<std::string, std::string> headers, std::string payload, std::shared_ptr<const Logger> logger) try {
+                             std::map<std::string, std::string> headers, std::string payload,
+                             std::shared_ptr<const Logger> logger) try {
   handle->setHeaders(headers);
 
   // We have to set the size manually, because msgpack uses null characters.
@@ -221,7 +224,7 @@ bool AgentWriter::postTraces(std::unique_ptr<Handle> &handle,
   if (rcode != CURLE_OK) {
     std::ostringstream error;
     error << "Error sending traces to agent: " << curl_easy_strerror(rcode) << "\n"
-              << handle->getError();
+          << handle->getError();
     logger->Log(LogLevel::error, error.str());
     return false;
   }

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -1,11 +1,11 @@
 #include "agent_writer.h"
 
-#include <iostream>
-
 #include "encoder.h"
 #include "sample.h"
 #include "span.h"
 #include "transport.h"
+
+#include <sstream>
 
 namespace datadog {
 namespace opentracing {
@@ -23,18 +23,21 @@ const long default_timeout_ms = 2000L;
 
 AgentWriter::AgentWriter(std::string host, uint32_t port, std::string url,
                          std::chrono::milliseconds write_period,
-                         std::shared_ptr<RulesSampler> sampler)
-    : AgentWriter(std::unique_ptr<Handle>{new CurlHandle{}}, write_period,
-                  default_max_queued_traces, default_retry_periods, host, port, url, sampler) {}
+                         std::shared_ptr<RulesSampler> sampler,
+                         std::shared_ptr<const Logger> logger)
+    // `CurlHandle` is defined in `transport.h`.
+    : AgentWriter(std::unique_ptr<Handle>{new CurlHandle{logger}}, write_period,
+                  default_max_queued_traces, default_retry_periods, host, port, url, sampler, logger) {}
 
 AgentWriter::AgentWriter(std::unique_ptr<Handle> handle, std::chrono::milliseconds write_period,
                          size_t max_queued_traces,
                          std::vector<std::chrono::milliseconds> retry_periods, std::string host,
-                         uint32_t port, std::string url, std::shared_ptr<RulesSampler> sampler)
-    : Writer(sampler),
+                         uint32_t port, std::string url, std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger)
+    : Writer(sampler, logger),
       write_period_(write_period),
       max_queued_traces_(max_queued_traces),
-      retry_periods_(retry_periods) {
+      retry_periods_(retry_periods),
+      logger_(logger) {
   setUpHandle(handle, host, port, url);
   startWriting(std::move(handle));
 }
@@ -153,7 +156,7 @@ void AgentWriter::startWriting(std::unique_ptr<Handle> handle) {
           }  // lock on mutex_ ends.
           // Send spans, not in critical period.
           bool success = retryFiniteOnFail(
-              [&]() { return AgentWriter::postTraces(handle, headers, payload); });
+              [&]() { return AgentWriter::postTraces(handle, headers, payload, logger_); });
           if (success) {
             trace_encoder_->handleResponse(handle->getResponse());
           }
@@ -194,26 +197,32 @@ bool AgentWriter::retryFiniteOnFail(std::function<bool()> f) const {
 }
 
 bool AgentWriter::postTraces(std::unique_ptr<Handle> &handle,
-                             std::map<std::string, std::string> headers, std::string payload) try {
+                             std::map<std::string, std::string> headers, std::string payload, std::shared_ptr<const Logger> logger) try {
   handle->setHeaders(headers);
 
   // We have to set the size manually, because msgpack uses null characters.
   CURLcode rcode = handle->setopt(CURLOPT_POSTFIELDSIZE, payload.size());
   if (rcode != CURLE_OK) {
-    std::cerr << "Error setting agent request size: " << curl_easy_strerror(rcode) << std::endl;
+    std::ostringstream error;
+    error << "Error setting agent request size: " << curl_easy_strerror(rcode);
+    logger->Log(LogLevel::error, error.str());
     return false;
   }
 
   rcode = handle->setopt(CURLOPT_POSTFIELDS, payload.data());
   if (rcode != CURLE_OK) {
-    std::cerr << "Error setting agent request body: " << curl_easy_strerror(rcode) << std::endl;
+    std::ostringstream error;
+    error << "Error setting agent request body: " << curl_easy_strerror(rcode);
+    logger->Log(LogLevel::error, error.str());
     return false;
   }
 
   rcode = handle->perform();
   if (rcode != CURLE_OK) {
-    std::cerr << "Error sending traces to agent: " << curl_easy_strerror(rcode) << std::endl
-              << handle->getError() << std::endl;
+    std::ostringstream error;
+    error << "Error sending traces to agent: " << curl_easy_strerror(rcode) << "\n"
+              << handle->getError();
+    logger->Log(LogLevel::error, error.str());
     return false;
   }
   return true;

--- a/src/agent_writer.h
+++ b/src/agent_writer.h
@@ -27,7 +27,8 @@ class AgentWriter : public Writer {
   // Creates an AgentWriter that uses curl to send Traces to a Datadog agent. May throw a
   // runtime_exception.
   AgentWriter(std::string host, uint32_t port, std::string unix_socket,
-              std::chrono::milliseconds write_period, std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger);
+              std::chrono::milliseconds write_period, std::shared_ptr<RulesSampler> sampler,
+              std::shared_ptr<const Logger> logger);
 
   AgentWriter(std::unique_ptr<Handle> handle, std::chrono::milliseconds write_period,
               size_t max_queued_traces, std::vector<std::chrono::milliseconds> retry_periods,
@@ -61,7 +62,8 @@ class AgentWriter : public Writer {
   void startWriting(std::unique_ptr<Handle> handle);
   // Posts the given Traces to the Agent. Returns true if it succeeds, otherwise false.
   static bool postTraces(std::unique_ptr<Handle> &handle,
-                         std::map<std::string, std::string> headers, std::string payload, std::shared_ptr<const Logger> logger);
+                         std::map<std::string, std::string> headers, std::string payload,
+                         std::shared_ptr<const Logger> logger);
   // Retries the given function a finite number of times according to retry_periods_. Retries when
   // f() returns false.
   bool retryFiniteOnFail(std::function<bool()> f) const;

--- a/src/agent_writer.h
+++ b/src/agent_writer.h
@@ -20,18 +20,19 @@ namespace opentracing {
 
 class Handle;
 
-// A Writer that sends Traces (collections of Spans) to a Datadog agent.
+// A Writer that manages a thread that sends Traces (collections of Spans) to a
+// Datadog agent.
 class AgentWriter : public Writer {
  public:
   // Creates an AgentWriter that uses curl to send Traces to a Datadog agent. May throw a
   // runtime_exception.
   AgentWriter(std::string host, uint32_t port, std::string unix_socket,
-              std::chrono::milliseconds write_period, std::shared_ptr<RulesSampler> sampler);
+              std::chrono::milliseconds write_period, std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger);
 
   AgentWriter(std::unique_ptr<Handle> handle, std::chrono::milliseconds write_period,
               size_t max_queued_traces, std::vector<std::chrono::milliseconds> retry_periods,
               std::string host, uint32_t port, std::string unix_socket,
-              std::shared_ptr<RulesSampler> sampler);
+              std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger);
 
   // Does not flush on destruction, buffered traces may be lost. Stops all threads.
   ~AgentWriter() override;
@@ -60,7 +61,7 @@ class AgentWriter : public Writer {
   void startWriting(std::unique_ptr<Handle> handle);
   // Posts the given Traces to the Agent. Returns true if it succeeds, otherwise false.
   static bool postTraces(std::unique_ptr<Handle> &handle,
-                         std::map<std::string, std::string> headers, std::string payload);
+                         std::map<std::string, std::string> headers, std::string payload, std::shared_ptr<const Logger> logger);
   // Retries the given function a finite number of times according to retry_periods_. Retries when
   // f() returns false.
   bool retryFiniteOnFail(std::function<bool()> f) const;
@@ -85,6 +86,9 @@ class AgentWriter : public Writer {
   bool stop_writing_ = false;
   // If set to true, flushes worker (which sets it false again). Locked by mutex_;
   bool flush_worker_ = false;
+  // The logger is used to print diagnostic messages.  The actual mechanism is
+  // determined by the `log_func` field of `TracerOptions`.
+  std::shared_ptr<const Logger> logger_;
 };
 
 }  // namespace opentracing

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -3,11 +3,10 @@
 #include <datadog/version.h>
 
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 #include "sample.h"
 #include "span.h"
-
-#include <sstream>
 
 using json = nlohmann::json;
 
@@ -25,7 +24,9 @@ const std::string header_dd_trace_count = "X-Datadog-Trace-Count";
 const size_t RESPONSE_ERROR_REGION_SIZE = 50;
 }  // namespace
 
-AgentHttpEncoder::AgentHttpEncoder(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger) : sampler_(sampler), logger_(logger) {
+AgentHttpEncoder::AgentHttpEncoder(std::shared_ptr<RulesSampler> sampler,
+                                   std::shared_ptr<const Logger> logger)
+    : sampler_(sampler), logger_(logger) {
   // Set up common headers and default encoder
   common_headers_ = {{header_content_type, "application/msgpack"},
                      {header_dd_meta_lang, "cpp"},
@@ -74,8 +75,8 @@ void AgentHttpEncoder::handleResponse(const std::string& response) {
       std::string response_region = response.substr(start, size);
       std::ostringstream diagnostic;
       diagnostic << "Unable to parse response from agent."
-                << "\nError was: " << error.what()
-                << "\nError near: " << prefix << response_region << suffix;
+                 << "\nError was: " << error.what() << "\nError near: " << prefix
+                 << response_region << suffix;
       logger_->Log(LogLevel::error, diagnostic.str());
       return;
     }

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -7,6 +7,8 @@
 #include "sample.h"
 #include "span.h"
 
+#include <sstream>
+
 using json = nlohmann::json;
 
 namespace datadog {
@@ -23,7 +25,7 @@ const std::string header_dd_trace_count = "X-Datadog-Trace-Count";
 const size_t RESPONSE_ERROR_REGION_SIZE = 50;
 }  // namespace
 
-AgentHttpEncoder::AgentHttpEncoder(std::shared_ptr<RulesSampler> sampler) : sampler_(sampler) {
+AgentHttpEncoder::AgentHttpEncoder(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger) : sampler_(sampler), logger_(logger) {
   // Set up common headers and default encoder
   common_headers_ = {{header_content_type, "application/msgpack"},
                      {header_dd_meta_lang, "cpp"},
@@ -70,9 +72,11 @@ void AgentHttpEncoder::handleResponse(const std::string& response) {
       std::string prefix = (start > 0) ? "..." : "";
       std::string suffix = ((start + size) < response.length()) ? "..." : "";
       std::string response_region = response.substr(start, size);
-      std::cerr << "Unable to parse response from agent." << std::endl
-                << "Error was: " << error.what() << std::endl
-                << "Error near: " << prefix << response_region << suffix << std::endl;
+      std::ostringstream diagnostic;
+      diagnostic << "Unable to parse response from agent."
+                << "\nError was: " << error.what()
+                << "\nError near: " << prefix << response_region << suffix;
+      logger_->Log(LogLevel::error, diagnostic.str());
       return;
     }
   }

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -3,11 +3,11 @@
 
 #include <datadog/opentracing.h>
 
-#include "logger.h"
-
 #include <deque>
 #include <memory>
 #include <sstream>
+
+#include "logger.h"
 
 namespace datadog {
 namespace opentracing {

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -3,19 +3,23 @@
 
 #include <datadog/opentracing.h>
 
+#include "logger.h"
+
 #include <deque>
+#include <memory>
 #include <sstream>
 
 namespace datadog {
 namespace opentracing {
 
+class Logger;
 class RulesSampler;
 struct SpanData;
 using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 
 class AgentHttpEncoder : public TraceEncoder {
  public:
-  AgentHttpEncoder(std::shared_ptr<RulesSampler> sampler);
+  AgentHttpEncoder(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger);
   ~AgentHttpEncoder() override {}
 
   // Returns the path that is used to submit HTTP requests to the agent.
@@ -37,6 +41,9 @@ class AgentHttpEncoder : public TraceEncoder {
   // Responses from the Agent may contain configuration for the sampler. May be nullptr if priority
   // sampling is not enabled.
   std::shared_ptr<RulesSampler> sampler_ = nullptr;
+  // The logger is used to print diagnostic messages.  The actual mechanism is
+  // determined by the `log_func` field of `TracerOptions`.
+  std::shared_ptr<const Logger> logger_;
 };
 
 }  // namespace opentracing

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,7 +1,8 @@
 #include "logger.h"
-#include "bool.h"
 
 #include <cstdlib>
+
+#include "bool.h"
 
 namespace datadog {
 namespace opentracing {

--- a/src/logger.h
+++ b/src/logger.h
@@ -3,6 +3,8 @@
 
 #include "datadog/opentracing.h"
 
+#include <memory>
+
 namespace datadog {
 namespace opentracing {
 
@@ -48,6 +50,10 @@ class VerboseLogger final : public Logger {
   void Trace(uint64_t trace_id, ot::string_view message) const noexcept override;
   void Trace(uint64_t trace_id, uint64_t span_id, ot::string_view message) const noexcept override;
 };
+
+// Return a `Logger` instance configured using the specified `options`.  The
+// returned value will not be null.
+std::shared_ptr<const Logger> makeLogger(const TracerOptions& options);
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,9 +1,9 @@
 #ifndef DD_OPENTRACING_LOGGER_H
 #define DD_OPENTRACING_LOGGER_H
 
-#include "datadog/opentracing.h"
-
 #include <memory>
+
+#include "datadog/opentracing.h"
 
 namespace datadog {
 namespace opentracing {

--- a/src/opentracing_agent.cpp
+++ b/src/opentracing_agent.cpp
@@ -6,9 +6,12 @@
 #include <datadog/opentracing.h>
 
 #include "agent_writer.h"
+#include "logger.h"
 #include "sample.h"
 #include "tracer.h"
 #include "tracer_options.h"
+
+#include <sstream>
 
 namespace ot = opentracing;
 
@@ -18,18 +21,21 @@ namespace opentracing {
 std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options) {
   auto maybe_options = applyTracerOptionsFromEnvironment(options);
   if (!maybe_options) {
-    std::cerr << "Error applying TracerOptions from environment variables: "
-              << maybe_options.error() << std::endl
-              << "Tracer will be started without options from the environment" << std::endl;
+    std::ostringstream message;
+    message << "Error applying TracerOptions from environment variables: "
+              << maybe_options.error()
+              << "\nTracer will be started without options from the environment\n";
+    StandardLogger(options.log_func).Log(LogLevel::error, message.str());
     maybe_options = options;
   }
   TracerOptions opts = maybe_options.value();
 
+  auto logger = makeLogger(opts);
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::shared_ptr<Writer>{
       new AgentWriter(opts.agent_host, opts.agent_port, opts.agent_url,
-                      std::chrono::milliseconds(llabs(opts.write_period_ms)), sampler)};
-  return std::shared_ptr<ot::Tracer>{new Tracer{opts, writer, sampler}};
+                      std::chrono::milliseconds(llabs(opts.write_period_ms)), sampler, logger)};
+  return std::shared_ptr<ot::Tracer>{new Tracer{opts, writer, sampler, logger}};
 }
 
 }  // namespace opentracing

--- a/src/opentracing_agent.cpp
+++ b/src/opentracing_agent.cpp
@@ -5,13 +5,13 @@
 
 #include <datadog/opentracing.h>
 
+#include <sstream>
+
 #include "agent_writer.h"
 #include "logger.h"
 #include "sample.h"
 #include "tracer.h"
 #include "tracer_options.h"
-
-#include <sstream>
 
 namespace ot = opentracing;
 
@@ -22,9 +22,8 @@ std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options) {
   auto maybe_options = applyTracerOptionsFromEnvironment(options);
   if (!maybe_options) {
     std::ostringstream message;
-    message << "Error applying TracerOptions from environment variables: "
-              << maybe_options.error()
-              << "\nTracer will be started without options from the environment\n";
+    message << "Error applying TracerOptions from environment variables: " << maybe_options.error()
+            << "\nTracer will be started without options from the environment\n";
     StandardLogger(options.log_func).Log(LogLevel::error, message.str());
     maybe_options = options;
   }

--- a/src/opentracing_external.cpp
+++ b/src/opentracing_external.cpp
@@ -22,17 +22,20 @@ namespace opentracing {
 
 std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTracerAndEncoder(
     const TracerOptions &options) {
+  // Creating the logger here assumes that there are no environment variable
+  // dependent settings for the logger, which is true.
+  auto logger = makeLogger(options);
+
   auto maybe_options = applyTracerOptionsFromEnvironment(options);
   if (!maybe_options) {
     std::ostringstream message;
     message << "Error applying TracerOptions from environment variables: " << maybe_options.error()
             << "\nTracer will be started without options from the environment\n";
-    StandardLogger(options.log_func).Log(LogLevel::error, message.str());
+    logger->Log(LogLevel::error, message.str());
     maybe_options = options;
   }
   TracerOptions opts = maybe_options.value();
 
-  auto logger = makeLogger(opts);
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::make_shared<ExternalWriter>(sampler, logger);
   auto encoder = writer->encoder();

--- a/src/opentracing_external.cpp
+++ b/src/opentracing_external.cpp
@@ -7,13 +7,13 @@
 
 #include <datadog/opentracing.h>
 
+#include <sstream>
+
 #include "logger.h"
 #include "sample.h"
 #include "tracer.h"
 #include "tracer_options.h"
 #include "writer.h"
-
-#include <sstream>
 
 namespace ot = opentracing;
 
@@ -25,9 +25,8 @@ std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTrace
   auto maybe_options = applyTracerOptionsFromEnvironment(options);
   if (!maybe_options) {
     std::ostringstream message;
-    message << "Error applying TracerOptions from environment variables: "
-              << maybe_options.error()
-              << "\nTracer will be started without options from the environment\n";
+    message << "Error applying TracerOptions from environment variables: " << maybe_options.error()
+            << "\nTracer will be started without options from the environment\n";
     StandardLogger(options.log_func).Log(LogLevel::error, message.str());
     maybe_options = options;
   }

--- a/src/opentracing_external.cpp
+++ b/src/opentracing_external.cpp
@@ -28,6 +28,9 @@ std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTrace
 
   auto maybe_options = applyTracerOptionsFromEnvironment(options);
   if (!maybe_options) {
+    // TODO(dgoffredo): Figure out a logging interface that allows for this
+    // formatting to be done within the (possibly no-op) logger rather than out
+    // here.
     std::ostringstream message;
     message << "Error applying TracerOptions from environment variables: " << maybe_options.error()
             << "\nTracer will be started without options from the environment\n";

--- a/src/opentracing_external.cpp
+++ b/src/opentracing_external.cpp
@@ -7,10 +7,13 @@
 
 #include <datadog/opentracing.h>
 
+#include "logger.h"
 #include "sample.h"
 #include "tracer.h"
 #include "tracer_options.h"
 #include "writer.h"
+
+#include <sstream>
 
 namespace ot = opentracing;
 
@@ -21,18 +24,21 @@ std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTrace
     const TracerOptions &options) {
   auto maybe_options = applyTracerOptionsFromEnvironment(options);
   if (!maybe_options) {
-    std::cerr << "Error applying TracerOptions from environment variables: "
-              << maybe_options.error() << std::endl
-              << "Tracer will be started without options from the environment" << std::endl;
+    std::ostringstream message;
+    message << "Error applying TracerOptions from environment variables: "
+              << maybe_options.error()
+              << "\nTracer will be started without options from the environment\n";
+    StandardLogger(options.log_func).Log(LogLevel::error, message.str());
     maybe_options = options;
   }
   TracerOptions opts = maybe_options.value();
 
+  auto logger = makeLogger(opts);
   auto sampler = std::make_shared<RulesSampler>();
-  auto writer = std::make_shared<ExternalWriter>(sampler);
+  auto writer = std::make_shared<ExternalWriter>(sampler, logger);
   auto encoder = writer->encoder();
   return std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>>{
-      std::shared_ptr<ot::Tracer>{new Tracer{opts, writer, sampler}}, encoder};
+      std::shared_ptr<ot::Tracer>{new Tracer{opts, writer, sampler, logger}}, encoder};
 }
 
 }  // namespace opentracing

--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -475,7 +475,8 @@ ot::expected<std::unique_ptr<ot::SpanContext>> SpanContext::deserialize(
     if (result.value() != nullptr) {
       if (context != nullptr && *dynamic_cast<SpanContext *>(result.value().get()) !=
                                     *dynamic_cast<SpanContext *>(context.get())) {
-        logger->Log(LogLevel::error, "Attempt to deserialize SpanContext with conflicting Datadog and B3 headers");
+        logger->Log(LogLevel::error,
+                    "Attempt to deserialize SpanContext with conflicting Datadog and B3 headers");
         return ot::make_unexpected(ot::span_context_corrupted_error);
       }
       context = std::move(result.value());
@@ -509,7 +510,8 @@ ot::expected<std::unique_ptr<ot::SpanContext>> SpanContext::deserialize(
             sampling_priority = asSamplingPriority(std::stoi(value));
             if (sampling_priority == nullptr) {
               // The sampling_priority key was present, but the value makes no sense.
-              logger->Log(LogLevel::error, "Invalid sampling_priority value in serialized SpanContext");
+              logger->Log(LogLevel::error,
+                          "Invalid sampling_priority value in serialized SpanContext");
               return ot::make_unexpected(ot::span_context_corrupted_error);
             }
           } else if (headers_impl.origin_header != nullptr &&

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -1,7 +1,5 @@
 #include "span_buffer.h"
 
-#include <iostream>
-
 #include "sample.h"
 #include "span.h"
 #include "writer.h"
@@ -109,12 +107,12 @@ void WritingSpanBuffer::finishSpan(std::unique_ptr<SpanData> span) {
   std::lock_guard<std::mutex> lock_guard{mutex_};
   auto trace_iter = traces_.find(span->traceId());
   if (trace_iter == traces_.end()) {
-    std::cerr << "Missing trace for finished span" << std::endl;
+    logger_->Log(LogLevel::error, "Missing trace for finished span");
     return;
   }
   auto& trace = trace_iter->second;
   if (trace.all_spans.find(span->spanId()) == trace.all_spans.end()) {
-    std::cerr << "A Span that was not registered was submitted to WritingSpanBuffer" << std::endl;
+    logger_->Log(LogLevel::error, "A Span that was not registered was submitted to WritingSpanBuffer");
     return;
   }
   uint64_t trace_id = span->traceId();

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -112,7 +112,8 @@ void WritingSpanBuffer::finishSpan(std::unique_ptr<SpanData> span) {
   }
   auto& trace = trace_iter->second;
   if (trace.all_spans.find(span->spanId()) == trace.all_spans.end()) {
-    logger_->Log(LogLevel::error, "A Span that was not registered was submitted to WritingSpanBuffer");
+    logger_->Log(LogLevel::error,
+                 "A Span that was not registered was submitted to WritingSpanBuffer");
     return;
   }
   uint64_t trace_id = span->traceId();

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -5,6 +5,7 @@
 #include <datadog/version.h>
 
 #include <functional>
+#include <memory>
 #include <random>
 
 #include "clock.h"
@@ -31,6 +32,7 @@ uint64_t getId();
 class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
  public:
   // Creates a Tracer by copying the given options and injecting the given dependencies.
+  // This overload is for use in unit tests.
   Tracer(TracerOptions options, std::shared_ptr<SpanBuffer> buffer, TimeProvider get_time,
          IdProvider get_id);
 
@@ -39,7 +41,7 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
   // an ExternalWriter that requires an external HTTP client to encode and submit to the Datadog
   // Agent.
   Tracer(TracerOptions options, std::shared_ptr<Writer> writer,
-         std::shared_ptr<RulesSampler> sampler);
+         std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger);
 
   Tracer() = delete;
 

--- a/src/tracer_factory.h
+++ b/src/tracer_factory.h
@@ -55,12 +55,13 @@ ot::expected<std::shared_ptr<ot::Tracer>> TracerFactory<TracerImpl>::MakeTracer(
   }
   TracerOptions options = maybe_options.value();
 
+  auto logger = makeLogger(options);
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::shared_ptr<Writer>{
       new AgentWriter(options.agent_host, options.agent_port, options.agent_url,
-                      std::chrono::milliseconds(llabs(options.write_period_ms)), sampler)};
+                      std::chrono::milliseconds(llabs(options.write_period_ms)), sampler, logger)};
 
-  return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler}};
+  return std::shared_ptr<ot::Tracer>{new TracerImpl{options, writer, sampler, logger}};
 } catch (const std::bad_alloc &) {
   return ot::make_unexpected(std::make_error_code(std::errc::not_enough_memory));
 } catch (const std::runtime_error &e) {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1,7 +1,6 @@
 #include "transport.h"
 
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 namespace datadog {
@@ -12,13 +11,14 @@ size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
   handle->response_buffer_.write(ptr, size * nmemb);
 
   if (!handle->response_buffer_) {
-    std::cerr << "Unable to write to response buffer" << std::endl;
+    handle->logger_->Log(LogLevel::error, "Unable to write to response buffer");
     return -1;
   }
   return size * nmemb;
 }
 
-CurlHandle::CurlHandle() {
+CurlHandle::CurlHandle(std::shared_ptr<const Logger> logger)
+: logger_(logger) {
   curl_global_init(CURL_GLOBAL_ALL);
   handle_ = curl_easy_init();
   // Set the error buffer.

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -17,8 +17,7 @@ size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
   return size * nmemb;
 }
 
-CurlHandle::CurlHandle(std::shared_ptr<const Logger> logger)
-: logger_(logger) {
+CurlHandle::CurlHandle(std::shared_ptr<const Logger> logger) : logger_(logger) {
   curl_global_init(CURL_GLOBAL_ALL);
   handle_ = curl_easy_init();
   // Set the error buffer.

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,6 +1,8 @@
 #ifndef DD_OPENTRACING_TRANSPORT_H
 #define DD_OPENTRACING_TRANSPORT_H
 
+#include "logger.h"
+
 #include <curl/curl.h>
 
 #include <map>
@@ -28,7 +30,7 @@ class Handle {
 class CurlHandle : public Handle {
  public:
   // May throw runtime_error.
-  CurlHandle();
+  explicit CurlHandle(std::shared_ptr<const Logger> logger);
   ~CurlHandle() override;
   CURLcode setopt(CURLoption key, const char* value) override;
   CURLcode setopt(CURLoption key, long value) override;
@@ -48,6 +50,7 @@ class CurlHandle : public Handle {
   std::map<std::string, std::string> headers_;
   char curl_error_buffer_[CURL_ERROR_SIZE];
   std::stringstream response_buffer_;  // So much more humane than a fixed sized buffer.
+  std::shared_ptr<const Logger> logger_;
 
   // Called with the response from perform().
   friend size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata);

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,13 +1,13 @@
 #ifndef DD_OPENTRACING_TRANSPORT_H
 #define DD_OPENTRACING_TRANSPORT_H
 
-#include "logger.h"
-
 #include <curl/curl.h>
 
 #include <map>
 #include <sstream>
 #include <string>
+
+#include "logger.h"
 
 namespace datadog {
 namespace opentracing {

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -8,8 +8,8 @@
 namespace datadog {
 namespace opentracing {
 
-Writer::Writer(std::shared_ptr<RulesSampler> sampler)
-    : trace_encoder_(std::make_shared<AgentHttpEncoder>(sampler)) {}
+Writer::Writer(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger)
+    : trace_encoder_(std::make_shared<AgentHttpEncoder>(sampler, logger)) {}
 
 void ExternalWriter::write(Trace trace) { trace_encoder_->addTrace(std::move(trace)); }
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -41,7 +41,8 @@ class Writer {
 // to the Datadog Agent.
 class ExternalWriter : public Writer {
  public:
-  ExternalWriter(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger) : Writer(sampler, logger) {}
+  ExternalWriter(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger)
+      : Writer(sampler, logger) {}
   ~ExternalWriter() override {}
 
   // Implements Writer methods.

--- a/src/writer.h
+++ b/src/writer.h
@@ -9,6 +9,7 @@
 #include <thread>
 
 #include "encoder.h"
+#include "logger.h"
 
 namespace datadog {
 namespace opentracing {
@@ -21,7 +22,7 @@ using Trace = std::unique_ptr<std::vector<std::unique_ptr<SpanData>>>;
 // A Writer is used to submit completed traces to the Datadog agent.
 class Writer {
  public:
-  Writer(std::shared_ptr<RulesSampler> sampler);
+  Writer(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger);
 
   virtual ~Writer() {}
 
@@ -40,7 +41,7 @@ class Writer {
 // to the Datadog Agent.
 class ExternalWriter : public Writer {
  public:
-  ExternalWriter(std::shared_ptr<RulesSampler> sampler) : Writer(sampler) {}
+  ExternalWriter(std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger) : Writer(sampler, logger) {}
   ~ExternalWriter() override {}
 
   // Implements Writer methods.

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -48,8 +48,15 @@ TEST_CASE("writer") {
     }));
     test_case.expected_opts[CURLOPT_TIMEOUT_MS] = "2000";
 
-    AgentWriter writer{std::move(handle_ptr), std::chrono::seconds(1), 100,           {},
-                       test_case.host,        test_case.port,          test_case.url, sampler, std::make_shared<MockLogger>()};
+    AgentWriter writer{std::move(handle_ptr),
+                       std::chrono::seconds(1),
+                       100,
+                       {},
+                       test_case.host,
+                       test_case.port,
+                       test_case.url,
+                       sampler,
+                       std::make_shared<MockLogger>()};
 
     REQUIRE(handle->options == test_case.expected_opts);
   }
@@ -201,7 +208,8 @@ TEST_CASE("writer") {
         {TestSpanData{"web", "service", "service.name", "resource", 1, 1, 0, 69, 420, 0}}));
     // Redirect stderr so the test logs don't look like a failure.
     writer.flush(std::chrono::seconds(10));  // Doesn't throw an error. That's the test!
-    REQUIRE(logger->records.back().message == "Error setting agent request size: Timeout was reached");
+    REQUIRE(logger->records.back().message ==
+            "Error setting agent request size: Timeout was reached");
     // Dropped all spans.
     handle->rcode = CURLE_OK;
     REQUIRE(handle->getTraces()->size() == 0);
@@ -213,7 +221,8 @@ TEST_CASE("writer") {
     writer.write(make_trace(
         {TestSpanData{"web", "service", "service.name", "resource", 1, 1, 0, 69, 420, 0}}));
     writer.flush(std::chrono::seconds(10));
-    REQUIRE(logger->records.back().message == "Error sending traces to agent: Timeout was reached\nerror from libcurl");
+    REQUIRE(logger->records.back().message ==
+            "Error sending traces to agent: Timeout was reached\nerror from libcurl");
   }
 
   SECTION("responses are not sent to sampler if the conenction fails") {

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -86,7 +86,7 @@ TEST_CASE("writer") {
   size_t max_queued_traces = 25;
   std::vector<std::chrono::milliseconds> disable_retry;
 
-  auto logger = std::make_shared<const Journal>();
+  auto logger = std::make_shared<const MockLogger>();
 
   AgentWriter writer{std::move(handle_ptr),
                      only_send_traces_when_we_flush,

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 
 #include "../src/sample.h"
@@ -31,13 +32,47 @@ struct MockLogger : public Logger {
   void Trace(uint64_t, uint64_t, ot::string_view) const noexcept override {}
 };
 
+// `Journal` is an implementation of `Logger` that appends logged records to an
+// internal `vector`, `records`.
+struct Journal : public Logger {
+  struct Record {
+    LogLevel level;
+    uint64_t trace_id; // zero if absent
+    uint64_t span_id; // zero if absent
+    std::string message;
+  };
+
+  mutable std::vector<Record> records;
+
+  Journal() : Logger([](LogLevel, ot::string_view) {}) {}
+  void Log(LogLevel level, ot::string_view message) const noexcept override {
+    records.push_back(Record{level, 0, 0, message});
+  }
+  void Log(LogLevel level, uint64_t trace_id, ot::string_view message) const noexcept override {
+    records.push_back(Record{level, trace_id, 0, message});
+  }
+  void Log(LogLevel level, uint64_t trace_id, uint64_t span_id, ot::string_view message) const noexcept override {
+    records.push_back(Record{level, trace_id, span_id, message});
+  }
+  void Trace(ot::string_view message) const noexcept override {
+    records.push_back(Record{LogLevel::debug, 0, 0, message});
+  }
+  void Trace(uint64_t trace_id, ot::string_view message) const noexcept override {
+    records.push_back(Record{LogLevel::debug, trace_id, 0, message});
+  }
+  void Trace(uint64_t trace_id, uint64_t span_id, ot::string_view message) const noexcept override {
+    records.push_back(Record{LogLevel::debug, trace_id, span_id, message});
+  }
+};
+
 // Exists just so we can see that opts was set correctly.
 struct MockTracer : public Tracer {
   TracerOptions opts;
 
   MockTracer(TracerOptions opts, std::shared_ptr<Writer> writer,
-             std::shared_ptr<RulesSampler> sampler)
-      : Tracer(opts, writer, sampler), opts(opts) {}
+             std::shared_ptr<RulesSampler> sampler,
+             std::shared_ptr<const Logger> logger)
+      : Tracer(opts, writer, sampler, logger), opts(opts) {}
 
   std::unique_ptr<ot::Span> StartSpanWithOptions(ot::string_view /* operation_name */,
                                                  const ot::StartSpanOptions& /* options */) const
@@ -140,7 +175,7 @@ struct MockRulesSampler : public RulesSampler {
 
 // A Writer implementation that allows access to the Spans recorded.
 struct MockWriter : public Writer {
-  MockWriter(std::shared_ptr<RulesSampler> sampler) : Writer(sampler) {}
+  MockWriter(std::shared_ptr<RulesSampler> sampler) : Writer(sampler, std::make_shared<MockLogger>()) {}
   ~MockWriter() override {}
 
   void write(Trace trace) override {

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -21,20 +21,9 @@
 namespace datadog {
 namespace opentracing {
 
+// `MockLogger` is an implementation of `Logger` that appends logged records to
+// an internal `vector`, `records`.
 struct MockLogger : public Logger {
- public:
-  MockLogger() : Logger([](LogLevel, ot::string_view) {}) {}
-  void Log(LogLevel, ot::string_view) const noexcept override {}
-  void Log(LogLevel, uint64_t, ot::string_view) const noexcept override {}
-  void Log(LogLevel, uint64_t, uint64_t, ot::string_view) const noexcept override {}
-  void Trace(ot::string_view) const noexcept override {}
-  void Trace(uint64_t, ot::string_view) const noexcept override {}
-  void Trace(uint64_t, uint64_t, ot::string_view) const noexcept override {}
-};
-
-// `Journal` is an implementation of `Logger` that appends logged records to an
-// internal `vector`, `records`.
-struct Journal : public Logger {
   struct Record {
     LogLevel level;
     uint64_t trace_id;  // zero if absent
@@ -44,7 +33,7 @@ struct Journal : public Logger {
 
   mutable std::vector<Record> records;
 
-  Journal() : Logger([](LogLevel, ot::string_view) {}) {}
+  MockLogger() : Logger([](LogLevel, ot::string_view) {}) {}
   void Log(LogLevel level, ot::string_view message) const noexcept override {
     records.push_back(Record{level, 0, 0, message});
   }

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -37,8 +37,8 @@ struct MockLogger : public Logger {
 struct Journal : public Logger {
   struct Record {
     LogLevel level;
-    uint64_t trace_id; // zero if absent
-    uint64_t span_id; // zero if absent
+    uint64_t trace_id;  // zero if absent
+    uint64_t span_id;   // zero if absent
     std::string message;
   };
 
@@ -51,7 +51,8 @@ struct Journal : public Logger {
   void Log(LogLevel level, uint64_t trace_id, ot::string_view message) const noexcept override {
     records.push_back(Record{level, trace_id, 0, message});
   }
-  void Log(LogLevel level, uint64_t trace_id, uint64_t span_id, ot::string_view message) const noexcept override {
+  void Log(LogLevel level, uint64_t trace_id, uint64_t span_id, ot::string_view message) const
+      noexcept override {
     records.push_back(Record{level, trace_id, span_id, message});
   }
   void Trace(ot::string_view message) const noexcept override {
@@ -60,7 +61,8 @@ struct Journal : public Logger {
   void Trace(uint64_t trace_id, ot::string_view message) const noexcept override {
     records.push_back(Record{LogLevel::debug, trace_id, 0, message});
   }
-  void Trace(uint64_t trace_id, uint64_t span_id, ot::string_view message) const noexcept override {
+  void Trace(uint64_t trace_id, uint64_t span_id, ot::string_view message) const
+      noexcept override {
     records.push_back(Record{LogLevel::debug, trace_id, span_id, message});
   }
 };
@@ -70,8 +72,7 @@ struct MockTracer : public Tracer {
   TracerOptions opts;
 
   MockTracer(TracerOptions opts, std::shared_ptr<Writer> writer,
-             std::shared_ptr<RulesSampler> sampler,
-             std::shared_ptr<const Logger> logger)
+             std::shared_ptr<RulesSampler> sampler, std::shared_ptr<const Logger> logger)
       : Tracer(opts, writer, sampler, logger), opts(opts) {}
 
   std::unique_ptr<ot::Span> StartSpanWithOptions(ot::string_view /* operation_name */,
@@ -175,7 +176,8 @@ struct MockRulesSampler : public RulesSampler {
 
 // A Writer implementation that allows access to the Spans recorded.
 struct MockWriter : public Writer {
-  MockWriter(std::shared_ptr<RulesSampler> sampler) : Writer(sampler, std::make_shared<MockLogger>()) {}
+  MockWriter(std::shared_ptr<RulesSampler> sampler)
+      : Writer(sampler, std::make_shared<MockLogger>()) {}
   ~MockWriter() override {}
 
   void write(Trace trace) override {

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("rules sampler") {
     {"name": "overridden operation name", "sample_rate": 0.4},
     {"sample_rate": 1.0}
 ])";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
     struct RulesSamplerTestCase {
       std::string service;
       std::string name;
@@ -123,7 +123,7 @@ TEST_CASE("rules sampler") {
     tracer_options.sampling_rules = R"([
     {"name": "unmatched.name", "service": "unmatched.service", "sample_rate": 0.1}
 ])";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
     auto span = tracer->StartSpanWithOptions("operation.name", span_options);
     span->FinishWithOptions(finish_options);
@@ -142,7 +142,7 @@ TEST_CASE("rules sampler") {
     {"sample_rate": 1.0}
 ])";
     tracer_options.operation_name_override = "overridden operation name";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
     auto span = tracer->StartSpanWithOptions("operation name", span_options);
     span->FinishWithOptions(finish_options);
@@ -158,7 +158,7 @@ TEST_CASE("rules sampler") {
     tracer_options.sampling_rules = R"([
     {"sample_rate": 0.0}
 ])";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
     auto span = tracer->StartSpanWithOptions("operation name", span_options);
     span->FinishWithOptions(finish_options);
@@ -188,7 +188,7 @@ TEST_CASE("rules sampler") {
       tracer_options.sampling_rules = R"([
     {"sample_rate": 0.0}
 ])";
-      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
       const auto span = tracer->StartSpanWithOptions("operation name", span_options);
       span->FinishWithOptions(finish_options);
@@ -207,7 +207,7 @@ TEST_CASE("rules sampler") {
       tracer_options.sampling_rules = R"([
     {"sample_rate": 1.0}
 ])";
-      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
       const auto span = tracer->StartSpanWithOptions("operation name", span_options);
       span->FinishWithOptions(finish_options);
@@ -226,7 +226,7 @@ TEST_CASE("rules sampler") {
       tracer_options.sampling_rules = R"([
     {"sample_rate": 1.0}
 ])";
-      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler);
+      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
       // The first span will be allowed by the limiter (tested in the previous section).
       auto span = tracer->StartSpanWithOptions("operation name", span_options);

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -95,7 +95,8 @@ TEST_CASE("rules sampler") {
     {"name": "overridden operation name", "sample_rate": 0.4},
     {"sample_rate": 1.0}
 ])";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+    auto tracer =
+        std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
     struct RulesSamplerTestCase {
       std::string service;
       std::string name;
@@ -123,7 +124,8 @@ TEST_CASE("rules sampler") {
     tracer_options.sampling_rules = R"([
     {"name": "unmatched.name", "service": "unmatched.service", "sample_rate": 0.1}
 ])";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+    auto tracer =
+        std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
     auto span = tracer->StartSpanWithOptions("operation.name", span_options);
     span->FinishWithOptions(finish_options);
@@ -142,7 +144,8 @@ TEST_CASE("rules sampler") {
     {"sample_rate": 1.0}
 ])";
     tracer_options.operation_name_override = "overridden operation name";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+    auto tracer =
+        std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
     auto span = tracer->StartSpanWithOptions("operation name", span_options);
     span->FinishWithOptions(finish_options);
@@ -158,7 +161,8 @@ TEST_CASE("rules sampler") {
     tracer_options.sampling_rules = R"([
     {"sample_rate": 0.0}
 ])";
-    auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+    auto tracer =
+        std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
 
     auto span = tracer->StartSpanWithOptions("operation name", span_options);
     span->FinishWithOptions(finish_options);
@@ -188,7 +192,8 @@ TEST_CASE("rules sampler") {
       tracer_options.sampling_rules = R"([
     {"sample_rate": 0.0}
 ])";
-      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler,
+                                                   std::make_shared<MockLogger>());
 
       const auto span = tracer->StartSpanWithOptions("operation name", span_options);
       span->FinishWithOptions(finish_options);
@@ -207,7 +212,8 @@ TEST_CASE("rules sampler") {
       tracer_options.sampling_rules = R"([
     {"sample_rate": 1.0}
 ])";
-      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler,
+                                                   std::make_shared<MockLogger>());
 
       const auto span = tracer->StartSpanWithOptions("operation name", span_options);
       span->FinishWithOptions(finish_options);
@@ -226,7 +232,8 @@ TEST_CASE("rules sampler") {
       tracer_options.sampling_rules = R"([
     {"sample_rate": 1.0}
 ])";
-      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+      const auto tracer = std::make_shared<Tracer>(tracer_options, writer, sampler,
+                                                   std::make_shared<MockLogger>());
 
       // The first span will be allowed by the limiter (tested in the previous section).
       auto span = tracer->StartSpanWithOptions("operation name", span_options);

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -205,7 +205,7 @@ TEST_CASE("env overrides") {
     REQUIRE(maybe_options);
     TracerOptions opts = maybe_options.value();
     opts.log_func = [](LogLevel, ot::string_view) {};  // noise suppression
-    std::shared_ptr<Tracer> tracer{new Tracer{opts, writer, sampler}};
+    std::shared_ptr<Tracer> tracer{new Tracer{opts, writer, sampler, std::make_shared<MockLogger>()}};
 
     // Create span
     auto span = tracer->StartSpanWithOptions("/env-override", span_options);
@@ -269,7 +269,7 @@ TEST_CASE("startup log") {
 
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::make_shared<MockWriter>(sampler);
-  std::shared_ptr<Tracer> tracer{new Tracer{opts, writer, sampler}};
+  std::shared_ptr<Tracer> tracer{new Tracer{opts, writer, sampler, std::make_shared<MockLogger>()}};
 
   if (enabled) {
     REQUIRE(!ss.str().empty());

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -205,7 +205,8 @@ TEST_CASE("env overrides") {
     REQUIRE(maybe_options);
     TracerOptions opts = maybe_options.value();
     opts.log_func = [](LogLevel, ot::string_view) {};  // noise suppression
-    std::shared_ptr<Tracer> tracer{new Tracer{opts, writer, sampler, std::make_shared<MockLogger>()}};
+    std::shared_ptr<Tracer> tracer{
+        new Tracer{opts, writer, sampler, std::make_shared<MockLogger>()}};
 
     // Create span
     auto span = tracer->StartSpanWithOptions("/env-override", span_options);
@@ -269,7 +270,8 @@ TEST_CASE("startup log") {
 
   auto sampler = std::make_shared<RulesSampler>();
   auto writer = std::make_shared<MockWriter>(sampler);
-  std::shared_ptr<Tracer> tracer{new Tracer{opts, writer, sampler, std::make_shared<MockLogger>()}};
+  std::shared_ptr<Tracer> tracer{
+      new Tracer{opts, writer, sampler, std::make_shared<MockLogger>()}};
 
   if (enabled) {
     REQUIRE(!ss.str().empty());


### PR DESCRIPTION
As part of my work on the new nginx module, I'm plugging this library's logging into nginx's logging system. I noticed that some of our library prints directly to standard error rather than using a `Logger` object. This revision makes a `Logger` object available to more components in the library.