### PR TITLE
Update container connections for compiled in and dynamic loading examples

### DIFF
--- a/examples/cpp-tracing/compiled-in/docker-compose.yml
+++ b/examples/cpp-tracing/compiled-in/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   dd-opentracing-cpp-example:
     build:
       context: ./
+    environment:
+      - DD_AGENT_HOST=dd-agent
     depends_on:
       - dd-agent
   dd-agent:

--- a/examples/cpp-tracing/dynamic-loading/docker-compose.yml
+++ b/examples/cpp-tracing/dynamic-loading/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   dd-opentracing-cpp-example:
     build:
       context: ./
+    environment:
+      - DD_AGENT_HOST=dd-agent
     depends_on:
       - dd-agent
   dd-agent:

--- a/examples/cpp-tracing/dynamic-loading/tracer_example.cpp
+++ b/examples/cpp-tracing/dynamic-loading/tracer_example.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* argv[]) {
   // Read in the tracer's configuration.
   std::string tracer_config = R"({
       "service": "dynamic-load example",
-      "agent_host": "dd-agent",
+      "agent_host": "localhost",
       "agent_port": 8126
     })";
 


### PR DESCRIPTION
When building the current compiled in example, it will lead to this error about traces being refused:

```
Error sending traces to agent: Couldn't connect to server
Failed to connect to localhost port 8126: Connection refused
```

I am making this change to correct this so traces can be sent to the Datadog Agent container (defined as `dd-agent` in the `docker-compose.yml`).

I have updated both the dynamic loading and compiled-in examples so that they both use `localhost` in the code but **DD_AGENT_HOST** in the Docker Compose file.

With this update, this is the expected output of the start up logs:

Compiled-In Example:

```
info: DATADOG TRACER CONFIGURATION - {"agent_url":"http://dd-agent:8126","analytics_enabled":false,"analytics_sample_rate":null,"date":"2021-12-14T20:28:53+0000","enabled":true,"env":"","lang":"cpp","lang_version":"201402","report_hostname":false,"sampling_rules":"[{\"sample_rate\": 1.0}]","service":"compiled-in example","version":"v1.3.1"}
```

Dynamic Loading:
```
info: DATADOG TRACER CONFIGURATION - {"agent_url":"http://dd-agent:8126","analytics_enabled":false,"analytics_sample_rate":null,"date":"2021-12-14T20:36:14+0000","enabled":true,"env":"","lang":"cpp","lang_version":"201402","report_hostname":false,"sampling_rules":"[{\"sample_rate\": 1.0}]","service":"dynamic-load example","version":"v1.3.1"}
```