### PR TITLE
make the rules sample limiter and default sampling rate configurable

### DIFF
--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -66,10 +66,10 @@ struct TracerOptions {
   // The environment this trace belongs to. eg. "" (env:none), "staging", "prod". Can also be set
   // by the environment variable DD_ENV
   std::string environment = "";
-  // This option is deprecated and may be removed in future releases.
-  // It is equivalent to setting a sampling rule with only a "sample_rate".
-  // Values must be between 0.0 and 1.0 (inclusive)
-  double sample_rate = std::nan("");
+  // `sample_rate` is the default sampling rate for any trace unmatched by a
+  // sampling rule.  Setting `sample_rate` is equivalent to appending to
+  // `sampling_rules` a rule whose "sample_rate" is `sample_rate`.
+  double sample_rate = 1.0;
   // This option is deprecated, and may be removed in future releases.
   bool priority_sampling = true;
   // Rules sampling is applied when initiating traces to determine the sampling
@@ -79,7 +79,7 @@ struct TracerOptions {
   // Rules are applied in configured order, so a more specific match should be
   // specified before a less specific match.  There is an implicit rule at the
   // end of the list that matches any trace unmatched by other rules, and
-  // applies a sampling rate of 1.0.  If any rules are invalid, they are
+  // applies a sampling rate of `sample_rate`.  If any rules are invalid, they are
   // ignored. This option is also configurable as the environment variable
   // DD_TRACE_SAMPLING_RULES.
   std::string sampling_rules = "[]";

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -68,18 +68,25 @@ struct TracerOptions {
   std::string environment = "";
   // `sample_rate` is the default sampling rate for any trace unmatched by a
   // sampling rule.  Setting `sample_rate` is equivalent to appending to
-  // `sampling_rules` a rule whose "sample_rate" is `sample_rate`.
-  double sample_rate = 1.0;
+  // `sampling_rules` a rule whose "sample_rate" is `sample_rate`.  If
+  // `sample_rate` is NaN, then no default rule is added, and traces not
+  // matching any sampling rule are subject to "priority sampling," where the
+  // sampling rate is determined by the Datadog trace agent.  This option is
+  // also configurable as the environment variable DD_TRACE_SAMPLE_RATE.
+  double sample_rate = std::nan("");
   // This option is deprecated, and may be removed in future releases.
   bool priority_sampling = true;
   // Rules sampling is applied when initiating traces to determine the sampling
   // rate.  Configuration is specified as a JSON array of objects. Each object
   // must have a "sample_rate", while the "name" and "service" fields are
   // optional. The "sample_rate" value must be between 0.0 and 1.0 (inclusive).
-  // Rules are applied in configured order, so a more specific match should be
-  // specified before a less specific match.  There is an implicit rule at the
+  // Rules are checked in order, so a more specific rule should be specified
+  // before a less specific rule.  Note that if the `sample_rate` field of this
+  // `TracerOptions` has a non-NaN value, then there is an implicit rule at the
   // end of the list that matches any trace unmatched by other rules, and
-  // applies a sampling rate of `sample_rate`.  If any rules are invalid, they are
+  // applies a sampling rate of `sample_rate`.  If no rule matches a trace,
+  // then "priority sampling" is applied instead, where the sample rate is
+  // determined by the Datadog trace agent.  If any rules are invalid, they are
   // ignored. This option is also configurable as the environment variable
   // DD_TRACE_SAMPLING_RULES.
   std::string sampling_rules = "[]";

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -1,6 +1,7 @@
 #include "limiter.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <numeric>
 
@@ -26,6 +27,9 @@ Limiter::Limiter(TimeProvider now_func, long max_tokens, double refresh_rate,
   current_period_ = std::chrono::time_point_cast<std::chrono::seconds>(now);
   previous_rates_sum_ = std::accumulate(previous_rates_.begin(), previous_rates_.end(), 0.0);
 }
+
+Limiter::Limiter(TimeProvider now_func, double allowed_per_second)
+    : Limiter(now_func, long(std::ceil(allowed_per_second)), allowed_per_second, 1) {}
 
 LimitResult Limiter::allow() { return allow(1); }
 

--- a/src/limiter.h
+++ b/src/limiter.h
@@ -17,6 +17,7 @@ struct LimitResult {
 class Limiter {
  public:
   Limiter(TimeProvider clock, long max_tokens, double refresh_rate, long tokens_per_refresh);
+  Limiter(TimeProvider clock, double allowed_per_second);
 
   LimitResult allow();
   LimitResult allow(long tokens);

--- a/src/opentracing_agent.cpp
+++ b/src/opentracing_agent.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions &options) {
   TracerOptions opts = maybe_options.value();
 
   auto logger = makeLogger(opts);
-  auto sampler = std::make_shared<RulesSampler>();
+  auto sampler = std::make_shared<RulesSampler>(opts.sampling_limit_per_second);
   auto writer = std::shared_ptr<Writer>{
       new AgentWriter(opts.agent_host, opts.agent_port, opts.agent_url,
                       std::chrono::milliseconds(llabs(opts.write_period_ms)), sampler, logger)};

--- a/src/opentracing_external.cpp
+++ b/src/opentracing_external.cpp
@@ -39,7 +39,7 @@ std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTrace
   }
   TracerOptions opts = maybe_options.value();
 
-  auto sampler = std::make_shared<RulesSampler>();
+  auto sampler = std::make_shared<RulesSampler>(opts.sampling_limit_per_second);
   auto writer = std::make_shared<ExternalWriter>(sampler, logger);
   auto encoder = writer->encoder();
   return std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>>{

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -72,6 +72,9 @@ void PrioritySampler::configure(json config) {
 
 RulesSampler::RulesSampler() : sampling_limiter_(getRealTime, 100, 100.0, 1) {}
 
+RulesSampler::RulesSampler(double limit_per_second)
+    : sampling_limiter_(getRealTime, limit_per_second) {}
+
 RulesSampler::RulesSampler(TimeProvider clock, long max_tokens, double refresh_rate,
                            long tokens_per_refresh)
     : sampling_limiter_(clock, max_tokens, refresh_rate, tokens_per_refresh) {}

--- a/src/sample.h
+++ b/src/sample.h
@@ -69,6 +69,7 @@ using RuleFunc = std::function<RuleResult(const std::string&, const std::string&
 class RulesSampler {
  public:
   RulesSampler();
+  explicit RulesSampler(double limit_per_second);
   RulesSampler(TimeProvider clock, long max_tokens, double refresh_rate, long tokens_per_refresh);
   // Some of the member functions of this class are declared `virtual` so that
   // they can be overridden by `MockRulesSampler` for use in unit tests.

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -124,7 +124,9 @@ void startupLog(TracerOptions &options) {
   }
   j["analytics_enabled"] = options.analytics_enabled;
   j["analytics_sample_rate"] = options.analytics_rate;
-  j["sample_rate"] = options.sample_rate;
+  if (!std::isnan(options.sample_rate)) {
+    j["sample_rate"] = options.sample_rate;
+  }
   j["sampling_rules"] = options.sampling_rules;
   j["sampling_limit_per_second"] = options.sampling_limit_per_second;
   if (!options.tags.empty()) {

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -123,6 +123,7 @@ void startupLog(TracerOptions &options) {
   }
   j["analytics_enabled"] = options.analytics_enabled;
   j["analytics_sample_rate"] = options.analytics_rate;
+  j["sample_rate"] = options.sample_rate;
   j["sampling_rules"] = options.sampling_rules;
   j["sampling_limit_per_second"] = options.sampling_limit_per_second;
   if (!options.tags.empty()) {
@@ -236,9 +237,11 @@ void Tracer::configureRulesSampler(std::shared_ptr<RulesSampler> sampler) noexce
     logger_->Log(LogLevel::error, message.str());
   }
 
-  // Add an automatic "catch all" rule to the end that samples at 100%.
+  // Add an automatic "catch all" rule to the end that samples at the default
+  // sample rate.
+  const double sample_rate = opts_.sample_rate;
   sampler->addRule([=](const std::string &, const std::string &) -> RuleResult {
-    return {true, 1.0};
+    return {true, sample_rate};
   });
 }
 

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -124,6 +124,7 @@ void startupLog(TracerOptions &options) {
   j["analytics_enabled"] = options.analytics_enabled;
   j["analytics_sample_rate"] = options.analytics_rate;
   j["sampling_rules"] = options.sampling_rules;
+  j["sampling_limit_per_second"] = options.sampling_limit_per_second;
   if (!options.tags.empty()) {
     j["tags"] = options.tags;
   }

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -167,71 +167,78 @@ uint64_t traceTagsPropagationMaxLength(const TracerOptions & /*options*/, const 
 
 }  // namespace
 
-void Tracer::configureRulesSampler(std::shared_ptr<RulesSampler> sampler) noexcept try {
-  auto log_invalid_json = [&](const std::string &description, json &object) {
-    logger_->Log(LogLevel::info, description + ": " + object.get<std::string>());
-  };
-  json config = json::parse(opts_.sampling_rules);
-  for (auto &item : config.items()) {
-    auto rule = item.value();
-    if (!rule.is_object()) {
-      log_invalid_json("rules sampler: unexpected item in sampling rules", rule);
-      continue;
-    }
-    // "sample_rate" is mandatory
-    if (!rule.contains("sample_rate")) {
-      log_invalid_json("rules sampler: rule is missing 'sample_rate'", rule);
-      continue;
-    }
-    if (!rule.at("sample_rate").is_number()) {
-      log_invalid_json("rules sampler: invalid type for 'sample_rate' (expected number)", rule);
-      continue;
-    }
-    auto sample_rate = rule.at("sample_rate").get<json::number_float_t>();
-    if (!(sample_rate >= 0.0 && sample_rate <= 1.0)) {
-      log_invalid_json(
-          "rules sampler: invalid value for sample rate (expected value between 0.0 and 1.0)",
-          rule);
-    }
-    // "service" and "name" are optional
-    bool has_service = rule.contains("service") && rule.at("service").is_string();
-    bool has_name = rule.contains("name") && rule.at("name").is_string();
-    auto nan = std::nan("");
-    if (has_service && has_name) {
-      auto svc = rule.at("service").get<std::string>();
-      auto nm = rule.at("name").get<std::string>();
-      sampler->addRule([=](const std::string &service, const std::string &name) -> RuleResult {
-        if (service == svc && name == nm) {
+void Tracer::configureRulesSampler(std::shared_ptr<RulesSampler> sampler) noexcept {
+  try {
+    auto log_invalid_json = [&](const std::string &description, json &object) {
+      logger_->Log(LogLevel::info, description + ": " + object.get<std::string>());
+    };
+    json config = json::parse(opts_.sampling_rules);
+    for (auto &item : config.items()) {
+      auto rule = item.value();
+      if (!rule.is_object()) {
+        log_invalid_json("rules sampler: unexpected item in sampling rules", rule);
+        continue;
+      }
+      // "sample_rate" is mandatory
+      if (!rule.contains("sample_rate")) {
+        log_invalid_json("rules sampler: rule is missing 'sample_rate'", rule);
+        continue;
+      }
+      if (!rule.at("sample_rate").is_number()) {
+        log_invalid_json("rules sampler: invalid type for 'sample_rate' (expected number)", rule);
+        continue;
+      }
+      auto sample_rate = rule.at("sample_rate").get<json::number_float_t>();
+      if (!(sample_rate >= 0.0 && sample_rate <= 1.0)) {
+        log_invalid_json(
+            "rules sampler: invalid value for sample rate (expected value between 0.0 and 1.0)",
+            rule);
+      }
+      // "service" and "name" are optional
+      bool has_service = rule.contains("service") && rule.at("service").is_string();
+      bool has_name = rule.contains("name") && rule.at("name").is_string();
+      auto nan = std::nan("");
+      if (has_service && has_name) {
+        auto svc = rule.at("service").get<std::string>();
+        auto nm = rule.at("name").get<std::string>();
+        sampler->addRule([=](const std::string &service, const std::string &name) -> RuleResult {
+          if (service == svc && name == nm) {
+            return {true, sample_rate};
+          }
+          return {false, nan};
+        });
+      } else if (has_service) {
+        auto svc = rule.at("service").get<std::string>();
+        sampler->addRule([=](const std::string &service, const std::string &) -> RuleResult {
+          if (service == svc) {
+            return {true, sample_rate};
+          }
+          return {false, nan};
+        });
+      } else if (has_name) {
+        auto nm = rule.at("name").get<std::string>();
+        sampler->addRule([=](const std::string &, const std::string &name) -> RuleResult {
+          if (name == nm) {
+            return {true, sample_rate};
+          }
+          return {false, nan};
+        });
+      } else {
+        sampler->addRule([=](const std::string &, const std::string &) -> RuleResult {
           return {true, sample_rate};
-        }
-        return {false, nan};
-      });
-    } else if (has_service) {
-      auto svc = rule.at("service").get<std::string>();
-      sampler->addRule([=](const std::string &service, const std::string &) -> RuleResult {
-        if (service == svc) {
-          return {true, sample_rate};
-        }
-        return {false, nan};
-      });
-    } else if (has_name) {
-      auto nm = rule.at("name").get<std::string>();
-      sampler->addRule([=](const std::string &, const std::string &name) -> RuleResult {
-        if (name == nm) {
-          return {true, sample_rate};
-        }
-        return {false, nan};
-      });
-    } else {
-      sampler->addRule([=](const std::string &, const std::string &) -> RuleResult {
-        return {true, sample_rate};
-      });
+        });
+      }
     }
+  } catch (const json::parse_error &error) {
+    std::ostringstream message;
+    message << "rules sampler: unable to parse JSON config for rules sampler: " << error.what();
+    logger_->Log(LogLevel::error, message.str());
   }
-} catch (const json::parse_error &error) {
-  std::ostringstream message;
-  message << "rules sampler: unable to parse JSON config for rules sampler: " << error.what();
-  logger_->Log(LogLevel::error, message.str());
+
+  // Add an automatic "catch all" rule to the end that samples at 100%.
+  sampler->addRule([=](const std::string &, const std::string &) -> RuleResult {
+    return {true, 1.0};
+  });
 }
 
 Tracer::Tracer(TracerOptions options, std::shared_ptr<SpanBuffer> buffer, TimeProvider get_time,

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -88,9 +88,6 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
     if (config.find("sampling_limit_per_second") != config.end()) {
       config.at("sampling_limit_per_second").get_to(options.sampling_limit_per_second);
     }
-    if (config.find("sample_rate") != config.end()) {
-      config.at("sample_rate").get_to(options.sample_rate);
-    }
   } catch (const nlohmann::detail::type_error &) {
     error_message = "configuration has an argument with an incorrect type";
     return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -10,7 +10,7 @@ namespace opentracing {
 
 ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
                                               std::string &error_message) {
-  TracerOptions options{"localhost", 8126, "", "web", "", 1.0};
+  TracerOptions options;
   json config;
   try {
     config = json::parse(configuration);

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -88,6 +88,9 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
     if (config.find("sampling_limit_per_second") != config.end()) {
       config.at("sampling_limit_per_second").get_to(options.sampling_limit_per_second);
     }
+    if (config.find("sample_rate") != config.end()) {
+      config.at("sample_rate").get_to(options.sample_rate);
+    }
   } catch (const nlohmann::detail::type_error &) {
     error_message = "configuration has an argument with an incorrect type";
     return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -85,6 +85,9 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
     if (config.find("dd.trace.analytics-sample-rate") != config.end()) {
       config.at("dd.trace.analytics-sample-rate").get_to(options.analytics_rate);
     }
+    if (config.find("sampling_limit_per_second") != config.end()) {
+      config.at("sampling_limit_per_second").get_to(options.sampling_limit_per_second);
+    }
   } catch (const nlohmann::detail::type_error &) {
     error_message = "configuration has an argument with an incorrect type";
     return ot::make_unexpected(std::make_error_code(std::errc::invalid_argument));

--- a/src/tracer_factory.h
+++ b/src/tracer_factory.h
@@ -19,28 +19,9 @@ ot::expected<TracerOptions> optionsFromConfig(const char *configuration,
 template <class TracerImpl>
 class TracerFactory : public ot::TracerFactory {
  public:
-  // Accepts configuration in JSON format, with the following keys:
-  // "service": Required. A string, the name of the service.
-  // "agent_host": A string, defaults to localhost. Can also be set by the environment variable
-  //     DD_AGENT_HOST
-  // "agent_port": A number, defaults to 8126. "type": A string, defaults to web. Can also be set
-  //     by the environment variable DD_TRACE_AGENT_PORT
-  // "type": A string, defaults to web.
-  // "environment": A string, defaults to "". The environment this trace belongs to.
-  //     eg. "" (env:none), "staging", "prod". Can also be set by the environment variable
-  //     DD_ENV
-  // "sample_rate": A double, defaults to 1.0.
-  // "operation_name_override": A string, if not empty it overrides the operation name (and the
-  //     overridden operation name is recorded in the tag "operation").
-  // "propagation_style_extract": A list of strings, each string is one of "Datadog", "B3".
-  //     Defaults to ["Datadog"]. The type of headers to use to propagate
-  //     distributed traces. Can also be set by the environment variable
-  //     DD_PROPAGATION_STYLE_EXTRACT.
-  // "propagation_style_inject": A list of strings, each string is one of "Datadog", "B3". Defaults
-  //     to ["Datadog"]. The type of headers to use to receive distributed traces. Can also be set
-  //     by the environment variable DD_PROPAGATION_STYLE_INJECT.
-  //
-  // Extra keys will be ignored.
+  // Accepts configuration as a JSON object.  See `optionsFromConfig` in
+  // tracer_factory.cpp for a list of supported attributes.  Unsupported
+  // attributes are ignored.
   ot::expected<std::shared_ptr<ot::Tracer>> MakeTracer(const char *configuration,
                                                        std::string &error_message) const
       noexcept override;

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -97,7 +97,9 @@ ot::expected<double, std::string> parseDouble(const std::string &text, double mi
                   [](unsigned char ch) { return !std::isspace(ch); })) {
     return ot::make_unexpected("contains trailing non-floating-point characters: " + text);
   }
-  if (value < minimum || value > maximum) {
+  // Note: Check "not inside" instead of "outside" so that the error is
+  // triggered for NaN `value`.
+  if (!(value >= minimum && value <= maximum)) {
     std::ostringstream error;
     error << "not within the expected bounds [" << minimum << ", " << maximum << "]: " << value;
     return ot::make_unexpected(error.str());

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -3,7 +3,9 @@
 #include <datadog/tags.h>
 #include <opentracing/ext/tags.h>
 
+#include <limits>
 #include <regex>
+#include <sstream>
 
 #include "bool.h"
 
@@ -85,6 +87,36 @@ std::vector<std::string> tokenize_propagation_style(const std::string &input) {
   return result;
 }
 
+ot::expected<double, std::string> parseDouble(const std::string &text, double minimum,
+                                              double maximum,
+                                              const char *name_for_diagnostic) try {
+  std::size_t end_index;
+  const double value = std::stod(text, &end_index);
+  // If any of the remaining characters are not whitespace, then `text`
+  // contains something other than a floating point number.
+  if (std::any_of(text.begin() + end_index, text.end(),
+                  [](unsigned char ch) { return !std::isspace(ch); })) {
+    std::ostringstream error;
+    error << name_for_diagnostic << " has trailing non-floating-point characters: " << text;
+    return ot::make_unexpected(error.str());
+  }
+  if (value < minimum || value > maximum) {
+    std::ostringstream error;
+    error << name_for_diagnostic << " is not within the expected bounds [" << minimum << ", "
+          << maximum << "]: " << value;
+    return ot::make_unexpected(error.str());
+  }
+  return value;
+} catch (const std::invalid_argument &) {
+  std::ostringstream error;
+  error << name_for_diagnostic << " does not look like a double: " << text;
+  return ot::make_unexpected(error.str());
+} catch (const std::out_of_range &) {
+  std::ostringstream error;
+  error << name_for_diagnostic << " not within the range of a double: " << text;
+  return ot::make_unexpected(error.str());
+}
+
 }  // namespace
 
 ot::expected<std::set<PropagationStyle>> asPropagationStyle(
@@ -105,8 +137,10 @@ ot::expected<std::set<PropagationStyle>> asPropagationStyle(
   return propagation_styles;
 }
 
-ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
+ot::expected<TracerOptions, std::string> applyTracerOptionsFromEnvironment(
     const TracerOptions &input) {
+  using namespace std::string_literals;
+
   TracerOptions opts = input;
 
   auto environment = std::getenv("DD_ENV");
@@ -151,9 +185,9 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
     try {
       opts.agent_port = std::stoi(trace_agent_port);
     } catch (const std::invalid_argument &ia) {
-      return ot::make_unexpected("Value for DD_TRACE_AGENT_PORT is invalid");
+      return ot::make_unexpected("Value for DD_TRACE_AGENT_PORT is invalid"s);
     } catch (const std::out_of_range &oor) {
-      return ot::make_unexpected("Value for DD_TRACE_AGENT_PORT is out of range");
+      return ot::make_unexpected("Value for DD_TRACE_AGENT_PORT is out of range"s);
     }
   }
 
@@ -171,7 +205,7 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
   if (extract != nullptr && std::strlen(extract) > 0) {
     auto style_maybe = asPropagationStyle(tokenize_propagation_style(extract));
     if (!style_maybe) {
-      return ot::make_unexpected("Value for DD_PROPAGATION_STYLE_EXTRACT is invalid");
+      return ot::make_unexpected("Value for DD_PROPAGATION_STYLE_EXTRACT is invalid"s);
     }
     opts.extract = style_maybe.value();
   }
@@ -180,7 +214,7 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
   if (inject != nullptr && std::strlen(inject) > 0) {
     auto style_maybe = asPropagationStyle(tokenize_propagation_style(inject));
     if (!style_maybe) {
-      return ot::make_unexpected("Value for DD_PROPAGATION_STYLE_INJECT is invalid");
+      return ot::make_unexpected("Value for DD_PROPAGATION_STYLE_INJECT is invalid"s);
     }
     opts.inject = style_maybe.value();
   }
@@ -191,7 +225,7 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
     if (value.empty() || isbool(value)) {
       opts.report_hostname = stob(value, false);
     } else {
-      return ot::make_unexpected("Value for DD_TRACE_REPORT_HOSTNAME is invalid");
+      return ot::make_unexpected("Value for DD_TRACE_REPORT_HOSTNAME is invalid"s);
     }
   }
 
@@ -206,26 +240,30 @@ ot::expected<TracerOptions, const char *> applyTracerOptionsFromEnvironment(
         opts.analytics_rate = std::nan("");
       }
     } else {
-      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_ENABLED is invalid");
+      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_ENABLED is invalid"s);
     }
   }
 
   auto analytics_rate = std::getenv("DD_TRACE_ANALYTICS_SAMPLE_RATE");
   if (analytics_rate != nullptr) {
-    try {
-      double value = std::stod(analytics_rate);
-      if (value >= 0.0 && value <= 1.0) {
-        opts.analytics_enabled = true;
-        opts.analytics_rate = value;
-      } else {
-        return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid");
-      }
-    } catch (const std::invalid_argument &ia) {
-      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid");
-    } catch (const std::out_of_range &oor) {
-      return ot::make_unexpected("Value for DD_TRACE_ANALYTICS_SAMPLE_RATE is invalid");
+    auto maybe_value = parseDouble(analytics_rate, 0.0, 1.0, "DD_TRACE_ANALYTICS_SAMPLE_RATE");
+    if (!maybe_value) {
+      return ot::make_unexpected(maybe_value.error());
     }
+    opts.analytics_enabled = true;
+    opts.analytics_rate = maybe_value.value();
   }
+
+  auto sampling_limit_per_second = std::getenv("DD_TRACE_RATE_LIMIT");
+  if (sampling_limit_per_second != nullptr) {
+    auto maybe_value = parseDouble(sampling_limit_per_second, 0.0,
+                                   std::numeric_limits<double>::infinity(), "DD_TRACE_RATE_LIMIT");
+    if (!maybe_value) {
+      return ot::make_unexpected(maybe_value.error());
+    }
+    opts.sampling_limit_per_second = maybe_value.value();
+  }
+
   return opts;
 }
 

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -264,6 +264,15 @@ ot::expected<TracerOptions, std::string> applyTracerOptionsFromEnvironment(
     opts.sampling_limit_per_second = maybe_value.value();
   }
 
+  auto sample_rate = std::getenv("DD_TRACE_SAMPLE_RATE");
+  if (sample_rate != nullptr) {
+    auto maybe_value = parseDouble(sample_rate, 0.0, 1.0, "DD_TRACE_SAMPLE_RATE");
+    if (!maybe_value) {
+      return ot::make_unexpected(maybe_value.error());
+    }
+    opts.sample_rate = maybe_value.value();
+  }
+
   return opts;
 }
 

--- a/src/tracer_options.h
+++ b/src/tracer_options.h
@@ -20,7 +20,7 @@ ot::expected<std::set<PropagationStyle>> asPropagationStyle(
     const std::vector<std::string>& styles);
 
 // TODO(cgilmour): refactor this so it returns a "finalized options" type.
-ot::expected<TracerOptions, const char*> applyTracerOptionsFromEnvironment(
+ot::expected<TracerOptions, std::string> applyTracerOptionsFromEnvironment(
     const TracerOptions& input);
 
 }  // namespace opentracing

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -61,7 +61,7 @@ RUN rm -rf dd-opentracing-cpp/.build
 RUN mkdir -p dd-opentracing-cpp/.build
 WORKDIR dd-opentracing-cpp/.build
 RUN cmake -DBUILD_PLUGIN=ON -DBUILD_STATIC=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-RUN make
+RUN make "-j${MAKE_JOB_COUNT:-$(nproc)}"
 RUN make install
 WORKDIR ..
 
@@ -85,4 +85,5 @@ RUN go get github.com/jakm/msgpack-cli
 # Copy these last so that edits don't need as many image rebuild steps
 COPY ./test/integration/nginx/nginx_integration_test.sh ./
 COPY ./test/integration/nginx/expected_*.json ./
+# CMD [ "bash", "-x", "./nginx_integration_test.sh"]
 CMD [ "bash", "-x", "./nginx_integration_test.sh"]

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -85,5 +85,4 @@ RUN go get github.com/jakm/msgpack-cli
 # Copy these last so that edits don't need as many image rebuild steps
 COPY ./test/integration/nginx/nginx_integration_test.sh ./
 COPY ./test/integration/nginx/expected_*.json ./
-# CMD [ "bash", "-x", "./nginx_integration_test.sh"]
 CMD [ "bash", "-x", "./nginx_integration_test.sh"]

--- a/test/integration/nginx/expected_tc1.json
+++ b/test/integration/nginx/expected_tc1.json
@@ -12,9 +12,8 @@
         "upstream.address": ""
       },
       "metrics": {
-        "_dd.limit_psr": 1,
-        "_dd.rule_psr": 1,
-        "_sampling_priority_v1": 2
+        "_dd.agent_psr": 1,
+        "_sampling_priority_v1": 1
       },
       "name": "nginx.handle",
       "resource": "/",
@@ -35,9 +34,8 @@
         "upstream.address": ""
       },
       "metrics": {
-        "_dd.limit_psr": 1,
-        "_dd.rule_psr": 1,
-        "_sampling_priority_v1": 2
+        "_dd.agent_psr": 1,
+        "_sampling_priority_v1": 1
       },
       "name": "nginx.handle",
       "resource": "/",
@@ -58,9 +56,8 @@
         "upstream.address": ""
       },
       "metrics": {
-        "_dd.limit_psr": 1,
-        "_dd.rule_psr": 1,
-        "_sampling_priority_v1": 2
+        "_dd.agent_psr": 1,
+        "_sampling_priority_v1": 1
       },
       "name": "nginx.handle",
       "resource": "/",

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -73,7 +73,7 @@ function run_nginx() {
   wait_for_port 80
 }
 
-# TEST 1: Ensure the right traces sent to the agent.
+# Test 1: Ensure the right traces sent to the agent.
 # Start wiremock in background
 wiremock --port 8126 >/dev/null 2>&1 &
 # Wait for wiremock to start
@@ -105,7 +105,7 @@ then
 fi
 
 reset_test
-# TEST 2: Check that libcurl isn't writing to stdout
+# Test 2: Check that libcurl isn't writing to stdout
 run_nginx
 curl -s localhost?[1-10000] 1> /tmp/curl_log.txt
 
@@ -118,7 +118,7 @@ then
 fi
 
 reset_test
-# TEST 3: Check that creating a root span doesn't produce an error
+# Test 3: Check that creating a root span doesn't produce an error
 run_nginx
 curl -s localhost?[1-5] 1> /tmp/curl_log.txt
 
@@ -166,7 +166,7 @@ curl -s localhost/proxy/?[1-1000] 1> /tmp/curl_log.txt
 
 # Check the traces the agent got.
 GOT=$(get_n_traces 1000)
-RATE=$(echo $GOT | jq '[.[] | .[] | .metrics._sampling_priority_v1] | add/length')
+RATE=$(echo "$GOT" | jq '[.[] | .[] | .metrics._sampling_priority_v1] | add/length')
 if [ $(echo $RATE | jq '(. > 0.45) and (. < 0.55)') != "true" ]
 then
   echo "Test 4 failed: Sample rate should be ~0.5 but was $RATE"
@@ -203,7 +203,7 @@ run_nginx
 curl -s localhost/get_error/ 1> /tmp/curl_log.txt
 
 GOT=$(get_n_traces 1)
-ERROR=$(echo $GOT | jq '.[] | .[] | .error')
+ERROR=$(echo "$GOT" | jq '.[] | .[] | .error')
 
 if ! [ "$ERROR" = "1" ]
 then

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -5,9 +5,6 @@
 #  * Java, Golang 
 # Run this test from the Docker container or CircleCI.
 
-# Disable tracer startup logs for test purposes
-export DD_TRACE_STARTUP_LOGS=false
-
 NGINX_CONF_PATH=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p')
 NGINX_CONF=$(cat ${NGINX_CONF_PATH})
 TRACER_CONF_PATH=/etc/dd-config.json
@@ -73,7 +70,7 @@ function run_nginx() {
   wait_for_port 80
 }
 
-# Test 1: Ensure the right traces sent to the agent.
+echo "Test 1: Ensure the right traces sent to the agent."
 # Start wiremock in background
 wiremock --port 8126 >/dev/null 2>&1 &
 # Wait for wiremock to start
@@ -105,7 +102,7 @@ then
 fi
 
 reset_test
-# Test 2: Check that libcurl isn't writing to stdout
+echo "Test 2: Check that libcurl isn't writing to stdout"
 run_nginx
 curl -s localhost?[1-10000] 1> /tmp/curl_log.txt
 
@@ -118,7 +115,7 @@ then
 fi
 
 reset_test
-# Test 3: Check that creating a root span doesn't produce an error
+echo "Test 3: Check that creating a root span doesn't produce an error"
 run_nginx
 curl -s localhost?[1-5] 1> /tmp/curl_log.txt
 
@@ -128,16 +125,18 @@ then
   cat ${NGINX_ERROR_LOG}
   echo ""
   exit 1
-elif [ "$(cat ${NGINX_ERROR_LOG})" != "" ]
-then
-  echo "Other errors in nginx log file:"
-  cat ${NGINX_ERROR_LOG}
-  echo ""
-  exit 1
+# TODO: jeez...
 fi
+# elif [ "$(cat ${NGINX_ERROR_LOG})" != "" ]
+# then
+#   echo "Other errors in nginx log file:"
+#   cat ${NGINX_ERROR_LOG}
+#   echo ""
+#   exit 1
+# fi
 
 reset_test
-# Test 4: Check that priority sampling works.
+echo "Test 4: Check that priority sampling works."
 # Start the mock agent
 wiremock --port 8126 >/dev/null 2>&1 & wait_for_port 8126
 curl -s -X POST --data '{ "priority":10, "request": { "method": "ANY", "urlPattern": ".*" }, "response": { "status": 200, "body": "{\"rate_by_service\":{\"service:nginx,env:prod\":0.5, \"service:nginx,env:\":0.2, \"service:wrong,env:\":0.1, \"service:nginx,env:wrong\":0.9}}" }}' http://localhost:8126/__admin/mappings/new
@@ -189,7 +188,7 @@ then
 fi
 
 reset_test
-# Test 5: Ensure that NGINX errors are reported to Datadog
+echo "Test 5: Ensure that NGINX errors are reported to Datadog"
 wiremock --port 8126 >/dev/null 2>&1 &
 # Wait for wiremock to start
 wait_for_port 8126
@@ -213,7 +212,7 @@ fi
 
 reset_test
 
-# Test 6: Origin header is propagated and adds a tag
+echo "Test 6: Origin header is propagated and adds a tag"
 wiremock --port 8126 >/dev/null 2>&1 & wait_for_port 8126
 curl -s -X POST --data '{ "priority":10, "request": { "method": "ANY", "urlPattern": ".*" }, "response": { "status": 200, "body": "OK" }}' http://localhost:8126/__admin/mappings/new
 wiremock --port 8080 >/dev/null 2>&1 & wait_for_port 8080

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -5,6 +5,9 @@
 #  * Java, Golang 
 # Run this test from the Docker container or CircleCI.
 
+# Disable tracer startup logs (these tests consider any nginx output an error).
+export DD_TRACE_STARTUP_LOGS=false
+
 NGINX_CONF_PATH=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--conf-path=\([^ ]*\).*/\1/p')
 NGINX_CONF=$(cat ${NGINX_CONF_PATH})
 TRACER_CONF_PATH=/etc/dd-config.json
@@ -125,15 +128,13 @@ then
   cat ${NGINX_ERROR_LOG}
   echo ""
   exit 1
-# TODO: jeez...
+elif [ "$(cat ${NGINX_ERROR_LOG})" != "" ]
+then
+  echo "Other errors in nginx log file:"
+  cat ${NGINX_ERROR_LOG}
+  echo ""
+  exit 1
 fi
-# elif [ "$(cat ${NGINX_ERROR_LOG})" != "" ]
-# then
-#   echo "Other errors in nginx log file:"
-#   cat ${NGINX_ERROR_LOG}
-#   echo ""
-#   exit 1
-# fi
 
 reset_test
 echo "Test 4: Check that priority sampling works."

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -137,7 +137,59 @@ then
 fi
 
 reset_test
-# Test 4: Ensure that NGINX errors are reported to Datadog
+# Test 4: Check that priority sampling works.
+# Start the mock agent
+wiremock --port 8126 >/dev/null 2>&1 & wait_for_port 8126
+curl -s -X POST --data '{ "priority":10, "request": { "method": "ANY", "urlPattern": ".*" }, "response": { "status": 200, "body": "{\"rate_by_service\":{\"service:nginx,env:prod\":0.5, \"service:nginx,env:\":0.2, \"service:wrong,env:\":0.1, \"service:nginx,env:wrong\":0.9}}" }}' http://localhost:8126/__admin/mappings/new
+# Start a HTTP server to receive distributed traces.
+wiremock --port 8080 >/dev/null 2>&1 & wait_for_port 8080
+curl -s -X POST --data '{ "priority":10, "request": { "method": "ANY", "urlPattern": ".*" }, "response": { "status": 200, "body": "Hello World" }}' http://localhost:8080/__admin/mappings/new
+
+echo '{
+  "service": "nginx",
+  "operation_name_override": "nginx.handle",
+  "agent_host": "localhost",
+  "agent_port": 8126,
+  "sampling_rules": [],
+  "environment": "prod"
+}' > ${TRACER_CONF_PATH}
+
+run_nginx
+
+# Let the tracer make a first request with spans to the agent, this will allow the agent to return
+# the priority sampling config.
+curl -s localhost 1> /tmp/curl_log.txt
+get_n_traces 1 >/dev/null
+
+# Sample a bunch of requests.
+curl -s localhost/proxy/?[1-1000] 1> /tmp/curl_log.txt
+
+# Check the traces the agent got.
+GOT=$(get_n_traces 1000)
+RATE=$(echo $GOT | jq '[.[] | .[] | .metrics._sampling_priority_v1] | add/length')
+if [ $(echo $RATE | jq '(. > 0.45) and (. < 0.55)') != "true" ]
+then
+  echo "Test 4 failed: Sample rate should be ~0.5 but was $RATE"
+  exit 1
+fi
+
+# Check the priority sampling was propagated for distributed traces.
+PROP_RATE=$(curl -s http://localhost:8080/__admin/requests | jq -r '[.requests[].request.headers."x-datadog-sampling-priority" | tonumber] | add/length')
+if [ $RATE != $PROP_RATE ]
+then
+  echo "Test 4 failed: propagated sample rate should be $RATE but was $PROP_RATE"
+  exit 1
+fi
+
+# Check that there were no errors.
+if ! [ "$(cat ${NGINX_ERROR_LOG} | wc -w)" = 0 ]
+then
+  echo "Test 4 failed: Unexpected error in nginx logs:"
+  cat ${NGINX_ERROR_LOG}
+fi
+
+reset_test
+# Test 5: Ensure that NGINX errors are reported to Datadog
 wiremock --port 8126 >/dev/null 2>&1 &
 # Wait for wiremock to start
 wait_for_port 8126
@@ -161,7 +213,7 @@ fi
 
 reset_test
 
-# Test 5: Origin header is propagated and adds a tag
+# Test 6: Origin header is propagated and adds a tag
 wiremock --port 8126 >/dev/null 2>&1 & wait_for_port 8126
 curl -s -X POST --data '{ "priority":10, "request": { "method": "ANY", "urlPattern": ".*" }, "response": { "status": 200, "body": "OK" }}' http://localhost:8126/__admin/mappings/new
 wiremock --port 8080 >/dev/null 2>&1 & wait_for_port 8080

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE("limiter") {
   }
 
   SECTION("dedicated constructor configures based on desired allowed-per-second") {
-    const double per_second = 23.887;
+    const double per_second = 23.97;
     Limiter lim(get_time, per_second);
     for (int i = 0; i < 24; ++i) {
       auto result = lim.allow();

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -90,11 +90,11 @@ TEST_CASE("limiter") {
 
   SECTION("updates tokens at multi-second intervals") {
     Limiter lim(get_time, 1, 0.25, 1);  // replace tokens @ 0.25 per second (i.e. every 4 seconds)
-    
+
     // 0 seconds (0s)
     auto result = lim.allow();
     REQUIRE(result.allowed);
-    
+
     for (int i = 0; i < 3; ++i) {
       // 1s, 2s, 3s... still haven't released a token
       advanceTime(time, std::chrono::seconds(1));
@@ -123,7 +123,7 @@ TEST_CASE("limiter") {
     auto result = lim.allow();
     REQUIRE(!result.allowed);
 
-    advanceTime(time, std::chrono::milliseconds(int(1/per_second * 1000) + 1));
+    advanceTime(time, std::chrono::milliseconds(int(1 / per_second * 1000) + 1));
     result = lim.allow();
     REQUIRE(result.allowed);
     result = lim.allow();

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -111,4 +111,22 @@ TEST_CASE("limiter") {
     result = lim.allow();
     REQUIRE(!result.allowed);
   }
+
+  SECTION("dedicated constructor configures based on desired allowed-per-second") {
+    const double per_second = 23.887;
+    Limiter lim(get_time, per_second);
+    for (int i = 0; i < 24; ++i) {
+      auto result = lim.allow();
+      REQUIRE(result.allowed);
+    }
+
+    auto result = lim.allow();
+    REQUIRE(!result.allowed);
+
+    advanceTime(time, std::chrono::milliseconds(int(1/per_second * 1000) + 1));
+    result = lim.allow();
+    REQUIRE(result.allowed);
+    result = lim.allow();
+    REQUIRE(!result.allowed);
+  }
 }

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("limiter") {
   }
 
   SECTION("updates tokens at sub-second intervals") {
-    Limiter lim(get_time, 5, 5.0, 1);  // replace tokens @ 5.0 per second (ie: every 0.2s)
+    Limiter lim(get_time, 5, 5.0, 1);  // replace tokens @ 5.0 per second (i.e. every 0.2 seconds)
     // consume all the tokens first
     for (auto i = 0; i < 5; i++) {
       auto result = lim.allow();
@@ -86,5 +86,29 @@ TEST_CASE("limiter") {
     }
     all_consumed = lim.allow();
     REQUIRE(!all_consumed.allowed);
+  }
+
+  SECTION("updates tokens at multi-second intervals") {
+    Limiter lim(get_time, 1, 0.25, 1);  // replace tokens @ 0.25 per second (i.e. every 4 seconds)
+    
+    // 0 seconds (0s)
+    auto result = lim.allow();
+    REQUIRE(result.allowed);
+    
+    for (int i = 0; i < 3; ++i) {
+      // 1s, 2s, 3s... still haven't released a token
+      advanceTime(time, std::chrono::seconds(1));
+      result = lim.allow();
+      REQUIRE(!result.allowed);
+    }
+
+    // 4s... one token was just released
+    advanceTime(time, std::chrono::seconds(1));
+    result = lim.allow();
+    REQUIRE(result.allowed);
+
+    // still 4s... and we used that token already
+    result = lim.allow();
+    REQUIRE(!result.allowed);
   }
 }

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -142,7 +142,7 @@ TEST_CASE("rules sampler") {
   SECTION("falls back to catch-all rule if sample_rate is configured and no other rule matches") {
     TracerOptions tracer_options;
     tracer_options.service = "test.service";
-    tracer_options.sample_rate = 0.2;
+    tracer_options.sample_rate = 0.5;
     tracer_options.sampling_rules = R"([
     {"name": "unmatched.name", "service": "unmatched.service", "sample_rate": 0.1}
 ])";
@@ -154,7 +154,7 @@ TEST_CASE("rules sampler") {
 
     auto& metrics = mwriter->traces[0][0]->metrics;
     REQUIRE(metrics.find("_dd.rule_psr") != metrics.end());
-    REQUIRE(metrics.find("_dd.limit_psr") != metrics.end());
+    REQUIRE(metrics["_dd.rule_psr"] == 0.5);
     REQUIRE(metrics.find("_dd.agent_psr") == metrics.end());
   }
 

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -118,9 +118,31 @@ TEST_CASE("rules sampler") {
     }
   }
 
-  SECTION("falls back to built-in catch-all rule when no matching user-specified rule") {
+  SECTION("falls back to priority sampling when no matching rule") {
     TracerOptions tracer_options;
     tracer_options.service = "test.service";
+    // In addition to `tracer_options.sampling_rules`, there would be an
+    // implicit rule added if `tracer_options.sample_rate` were not NaN.  That
+    // case is handled in the next section (not this one).
+    tracer_options.sampling_rules = R"([
+    {"name": "unmatched.name", "service": "unmatched.service", "sample_rate": 0.1}
+])";
+    auto tracer =
+        std::make_shared<Tracer>(tracer_options, writer, sampler, std::make_shared<MockLogger>());
+
+    auto span = tracer->StartSpanWithOptions("operation.name", span_options);
+    span->FinishWithOptions(finish_options);
+
+    auto& metrics = mwriter->traces[0][0]->metrics;
+    REQUIRE(metrics.find("_dd.rule_psr") == metrics.end());
+    REQUIRE(metrics.find("_dd.limit_psr") == metrics.end());
+    REQUIRE(metrics.find("_dd.agent_psr") != metrics.end());
+  }
+
+  SECTION("falls back to catch-all rule if sample_rate is configured and no other rule matches") {
+    TracerOptions tracer_options;
+    tracer_options.service = "test.service";
+    tracer_options.sample_rate = 0.2;
     tracer_options.sampling_rules = R"([
     {"name": "unmatched.name", "service": "unmatched.service", "sample_rate": 0.1}
 ])";

--- a/test/sample_test.cpp
+++ b/test/sample_test.cpp
@@ -118,7 +118,7 @@ TEST_CASE("rules sampler") {
     }
   }
 
-  SECTION("falls back to priority sampling when no matching rule") {
+  SECTION("falls back to built-in catch-all rule when no matching user-specified rule") {
     TracerOptions tracer_options;
     tracer_options.service = "test.service";
     tracer_options.sampling_rules = R"([
@@ -131,9 +131,9 @@ TEST_CASE("rules sampler") {
     span->FinishWithOptions(finish_options);
 
     auto& metrics = mwriter->traces[0][0]->metrics;
-    REQUIRE(metrics.find("_dd.rule_psr") == metrics.end());
-    REQUIRE(metrics.find("_dd.limit_psr") == metrics.end());
-    REQUIRE(metrics.find("_dd.agent_psr") != metrics.end());
+    REQUIRE(metrics.find("_dd.rule_psr") != metrics.end());
+    REQUIRE(metrics.find("_dd.limit_psr") != metrics.end());
+    REQUIRE(metrics.find("_dd.agent_psr") == metrics.end());
   }
 
   SECTION("rule matching applied to overridden name") {

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -79,14 +79,15 @@ TEST_CASE("tracer options from environment variables") {
         {"DD_TRACE_ANALYTICS_ENABLED", "true"},
         {"DD_TRACE_ANALYTICS_SAMPLE_RATE", "0.5"},
         {"DD_TAGS", "host:my-host-name,region:us-east-1,datacenter:us,partition:5"},
-        {"DD_TRACE_RATE_LIMIT", "200"}},
+        {"DD_TRACE_RATE_LIMIT", "200"},
+        {"DD_TRACE_SAMPLE_RATE", "0.7"}},
        TracerOptions{
            "host",                                             // agent_host
            420,                                                // agent_port
            "service",                                          // service
            "web",                                              // type
            "test-env",                                         // environment
-           std::nan(""),                                       // sample_rate
+           0.7,                                                // sample_rate
            true,                                               // priority_sampling
            "rules",                                            // sampling_rules
            1000,                                               // write_period_ms

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -139,6 +139,9 @@ TEST_CASE("tracer options from environment variables") {
       {{{"DD_TRACE_SAMPLE_RATE", "1.6"}},
        ot::make_unexpected(
            "while parsing DD_TRACE_SAMPLE_RATE: not within the expected bounds [0, 1]: 1.6"s)},
+      {{{"DD_TRACE_SAMPLE_RATE", "NaN"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_SAMPLE_RATE: not within the expected bounds [0, 1]: nan"s)},
       {{{"DD_TRACE_SAMPLE_RATE", "0.5 BOOM"}},
        ot::make_unexpected(
            "while parsing DD_TRACE_SAMPLE_RATE: contains trailing non-floating-point characters: 0.5 BOOM"s)},
@@ -151,6 +154,9 @@ TEST_CASE("tracer options from environment variables") {
       {{{"DD_TRACE_RATE_LIMIT", "-8"}},
        ot::make_unexpected(
            "while parsing DD_TRACE_RATE_LIMIT: not within the expected bounds [0, inf]: -8"s)},
+      {{{"DD_TRACE_RATE_LIMIT", "NaN"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_RATE_LIMIT: not within the expected bounds [0, inf]: nan"s)},
       {{{"DD_TRACE_RATE_LIMIT", "0.5 BOOM"}},
        ot::make_unexpected(
            "while parsing DD_TRACE_RATE_LIMIT: contains trailing non-floating-point characters: 0.5 BOOM"s)},

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -123,7 +123,7 @@ TEST_CASE("tracer options from environment variables") {
        ot::make_unexpected("Value for DD_TRACE_ANALYTICS_ENABLED is invalid"s)},
       {{{"DD_TRACE_ANALYTICS_SAMPLE_RATE", "1.1"}},
        ot::make_unexpected(
-           "DD_TRACE_ANALYTICS_SAMPLE_RATE is not within the expected bounds [0, 1]: 1.1"s)},
+           "while parsing DD_TRACE_ANALYTICS_SAMPLE_RATE: not within the expected bounds [0, 1]: 1.1"s)},
   }));
 
   // Setup

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -106,7 +106,6 @@ TEST_CASE("tracer options from environment variables") {
            "test-version v0.0.1",             // version
            "",                                // agent_url
            [](LogLevel, ot::string_view) {},  // log_func (dummy)
-           512,                               // trace_tags_propagation_max_length
            200                                // sampling_limit_per_second
        }},
       {{{"DD_PROPAGATION_STYLE_EXTRACT", "Not even a real style"}},

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -124,6 +124,36 @@ TEST_CASE("tracer options from environment variables") {
       {{{"DD_TRACE_ANALYTICS_SAMPLE_RATE", "1.1"}},
        ot::make_unexpected(
            "while parsing DD_TRACE_ANALYTICS_SAMPLE_RATE: not within the expected bounds [0, 1]: 1.1"s)},
+      // Each of DD_TRACE_SAMPLE_RATE and DD_TRACE_RATE_LIMIT can fail to parse
+      // for any of the following reasons:
+      // - not a floating point number
+      // - can't fit in a double
+      // - outside of the expected range (e.g. [0, 1] for DD_TRACE_SAMPLE_RATE)
+      // - has non-whitespace trailing characters
+      {{{"DD_TRACE_SAMPLE_RATE", "total nonsense"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_SAMPLE_RATE: does not look like a double: total nonsense"s)},
+      {{{"DD_TRACE_SAMPLE_RATE", "3.14e99999"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_SAMPLE_RATE: not within the range of a double: 3.14e99999"s)},
+      {{{"DD_TRACE_SAMPLE_RATE", "1.6"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_SAMPLE_RATE: not within the expected bounds [0, 1]: 1.6"s)},
+      {{{"DD_TRACE_SAMPLE_RATE", "0.5 BOOM"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_SAMPLE_RATE: contains trailing non-floating-point characters: 0.5 BOOM"s)},
+      {{{"DD_TRACE_RATE_LIMIT", "total nonsense"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_RATE_LIMIT: does not look like a double: total nonsense"s)},
+      {{{"DD_TRACE_RATE_LIMIT", "3.14e99999"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_RATE_LIMIT: not within the range of a double: 3.14e99999"s)},
+      {{{"DD_TRACE_RATE_LIMIT", "-8"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_RATE_LIMIT: not within the expected bounds [0, inf]: -8"s)},
+      {{{"DD_TRACE_RATE_LIMIT", "0.5 BOOM"}},
+       ot::make_unexpected(
+           "while parsing DD_TRACE_RATE_LIMIT: contains trailing non-floating-point characters: 0.5 BOOM"s)},
   }));
 
   // Setup

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -55,6 +55,7 @@ void requireTracerOptionsResultsMatch(const ot::expected<TracerOptions, std::str
     REQUIRE(lhs->analytics_rate == rhs->analytics_rate);
   }
   REQUIRE(lhs->tags == rhs->tags);
+  REQUIRE(lhs->sampling_limit_per_second == rhs->sampling_limit_per_second);
 }
 
 TEST_CASE("tracer options from environment variables") {
@@ -77,30 +78,35 @@ TEST_CASE("tracer options from environment variables") {
         {"DD_TRACE_REPORT_HOSTNAME", "true"},
         {"DD_TRACE_ANALYTICS_ENABLED", "true"},
         {"DD_TRACE_ANALYTICS_SAMPLE_RATE", "0.5"},
-        {"DD_TAGS", "host:my-host-name,region:us-east-1,datacenter:us,partition:5"}},
+        {"DD_TAGS", "host:my-host-name,region:us-east-1,datacenter:us,partition:5"},
+        {"DD_TRACE_RATE_LIMIT", "200"}},
        TracerOptions{
-           "host",
-           420,
-           "service",
-           "web",
-           "test-env",
-           std::nan(""),
-           true,
-           "rules",
-           1000,
-           "",
-           {PropagationStyle::Datadog, PropagationStyle::B3},
-           {PropagationStyle::Datadog, PropagationStyle::B3},
-           true,
-           true,
-           0.5,
+           "host",                                             // agent_host
+           420,                                                // agent_port
+           "service",                                          // service
+           "web",                                              // type
+           "test-env",                                         // environment
+           std::nan(""),                                       // sample_rate
+           true,                                               // priority_sampling
+           "rules",                                            // sampling_rules
+           1000,                                               // write_period_ms
+           "",                                                 // operation_name_override
+           {PropagationStyle::Datadog, PropagationStyle::B3},  // extract
+           {PropagationStyle::Datadog, PropagationStyle::B3},  // inject
+           true,                                               // report_hostname
+           true,                                               // analytics_enabled
+           0.5,                                                // analytics_rate
            {
                {"host", "my-host-name"},
                {"region", "us-east-1"},
                {"datacenter", "us"},
                {"partition", "5"},
-           },
-           "test-version v0.0.1",
+           },                                 // tags
+           "test-version v0.0.1",             // version
+           "",                                // agent_url
+           [](LogLevel, ot::string_view) {},  // log_func (dummy)
+           512,                               // trace_tags_propagation_max_length
+           200                                // sampling_limit_per_second
        }},
       {{{"DD_PROPAGATION_STYLE_EXTRACT", "Not even a real style"}},
        ot::make_unexpected("Value for DD_PROPAGATION_STYLE_EXTRACT is invalid"s)},

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -199,7 +199,7 @@ TEST_CASE("env overrides") {
     ::setenv(env_test.env.c_str(), env_test.val.c_str(), 0);
     auto maybe_options = applyTracerOptionsFromEnvironment(tracer_options);
     if (env_test.error) {
-      REQUIRE(maybe_options.error());
+      REQUIRE(!maybe_options);
       return;
     }
     REQUIRE(maybe_options);


### PR DESCRIPTION
_Tip: Tell github to "hide whitespace" for this diff.  I moved some `try` blocks around, which changed indentation._

These revisions address the issue raised in customer issue APMS-6277 ("Attempting to use configuration 'max_traces_per_second' to limit tracing to 5 per second") and the work item OKR2,KR1 ("`DD_TRACE_SAMPLE_RATE` implemented and documented").

Brett mentioned that in `dd-trace-py`, the `DD_TRACE_SAMPLE_RATE` environment variable results in the equivalent sampling rule being appended to any other rules that the user might have specified. This means that agent-led priority sampling only happens if `DD_TRACE_SAMPLE_RATE` doesn't have a value.  Additionally, the rule-based sampler's limiter can be configured using the environment variable `DD_TRACE_RATE_LIMIT`.

All of that behavior is implemented here.