### PR TITLE
see if CircleCI will run us on an ARM-based Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
   docker:
     - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
-  resource_class: medium
+  resource_class: arm.medium
   environment: *default_environment
 
 jobs:


### PR DESCRIPTION
The base image of our build image isn't one of the two listed as supported: https://circleci.com/docs/2.0/arm-resources/#overview but let's see what happens.