### PR TITLE
Apply changes from #221 as one signed patch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(GNUInstallDirs)
 
 option(BUILD_SHARED "Builds shared library" ON)
 option(BUILD_STATIC "Builds static library" OFF)
+option(BUILD_OBJECT "Builds objects for use in another project" OFF)
 option(BUILD_PLUGIN "Builds plugin (requires gcc and not macos)" OFF)
 option(BUILD_TESTING "Builds tests, also enables BUILD_SHARED" OFF)
 option(BUILD_COVERAGE "Builds code with code coverage profiling instrumentation" OFF)
@@ -27,7 +28,6 @@ endif()
 set(CMAKE_CXX_STANDARD 14)
 
 # Includes
-set(CMAKE_INCLUDE_PATH 3rd_party/include deps/include)
 include_directories(SYSTEM 3rd_party/include deps/include)
 include_directories(include)
 
@@ -37,7 +37,6 @@ set(CMAKE_LIBRARY_PATH deps/lib)
 # Dependencies
 find_path(OPENTRACING_INCLUDE_DIR NAMES opentracing/tracer.h)
 find_library(OPENTRACING_LIB opentracing)
-find_package(ZLIB REQUIRED)
 find_library(MSGPACK_LIB msgpack)
 find_package(CURL)
 find_package(Threads REQUIRED)
@@ -65,7 +64,7 @@ endif()
 if(BUILD_COVERAGE)
   set(COVERAGE_LIBRARIES gcov)
 endif()
-set(DATADOG_LINK_LIBRARIES ${OPENTRACING_LIB} ${CURL_LIBRARIES} ${ZLIB_LIBRARIES} Threads::Threads ${COVERAGE_LIBRARIES})
+set(DATADOG_LINK_LIBRARIES ${OPENTRACING_LIB} ${CURL_LIBRARIES} Threads::Threads ${COVERAGE_LIBRARIES})
 
 ## Shared lib
 if(BUILD_SHARED)
@@ -92,6 +91,15 @@ if(BUILD_STATIC)
   install(TARGETS dd_opentracing-static
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+## Object lib
+if(BUILD_OBJECT)
+  add_library(dd_opentracing-object OBJECT ${DD_OPENTRACING_SOURCES})
+  add_sanitizers(dd_opentracing-object)
+  target_link_libraries(dd_opentracing-object ${CURL_LIBRARIES} Threads::Threads)
+  set_property(TARGET dd_opentracing-object PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_compile_definitions(dd_opentracing-object PUBLIC DD_OPENTRACING_OBJECT)
 endif()
 
 ## Plugin

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -179,6 +179,17 @@ DD_OPENTRACING_API std::shared_ptr<ot::Tracer> makeTracer(const TracerOptions& o
 std::tuple<std::shared_ptr<ot::Tracer>, std::shared_ptr<TraceEncoder>> makeTracerAndEncoder(
     const TracerOptions& options);
 
+// Return a JSON representation of the specified `options`.  If the specified
+// `with_timestamp` is `true`, then include a "date" field whose value is the
+// current date and time.
+// This function is defined in `tracer_options.cpp`.
+std::string toJSON(const TracerOptions& options, bool with_timestamp);
+
+// Return a reference to the options used to configure the specified `tracer`.
+// The behavior is undefined unless `tracer` is a Datadog tracer.
+// This function is defined in `tracer.cpp`.
+const TracerOptions& getOptions(const ot::Tracer& tracer);
+
 }  // namespace opentracing
 }  // namespace datadog
 

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -72,6 +72,8 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
 
   void Close() noexcept override;
 
+  const TracerOptions &options() const noexcept;
+
  private:
   void configureRulesSampler(std::shared_ptr<RulesSampler> sampler) noexcept;
 

--- a/src/tracer_factory.cpp
+++ b/src/tracer_factory.cpp
@@ -5,6 +5,8 @@
 
 using json = nlohmann::json;
 
+extern "C" char **environ;
+
 namespace datadog {
 namespace opentracing {
 

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -1,9 +1,12 @@
 #include "tracer_options.h"
 
 #include <datadog/tags.h>
+#include <datadog/version.h>
 #include <opentracing/ext/tags.h>
 
+#include <iomanip>
 #include <limits>
+#include <nlohmann/json.hpp>
 #include <regex>
 #include <sstream>
 
@@ -271,6 +274,43 @@ ot::expected<TracerOptions, std::string> applyTracerOptionsFromEnvironment(
   }
 
   return opts;
+}
+
+std::string toJSON(const TracerOptions &options, bool with_timestamp) {
+  nlohmann::json j;
+  if (with_timestamp) {
+    std::time_t t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&t), "%FT%T%z");
+    j["date"] = ss.str();
+  }
+  j["version"] = datadog::version::tracer_version;
+  j["lang"] = "cpp";
+  j["lang_version"] = datadog::version::cpp_version;
+  j["env"] = options.environment;
+  j["enabled"] = true;
+  j["service"] = options.service;
+  if (!options.agent_url.empty()) {
+    j["agent_url"] = options.agent_url;
+  } else {
+    j["agent_url"] =
+        std::string("http://") + options.agent_host + ":" + std::to_string(options.agent_port);
+  }
+  j["analytics_enabled"] = options.analytics_enabled;
+  j["analytics_sample_rate"] = options.analytics_rate;
+  j["sampling_rules"] = options.sampling_rules;
+  if (!options.tags.empty()) {
+    j["tags"] = options.tags;
+  }
+  if (!options.version.empty()) {
+    j["dd_version"] = options.version;
+  }
+  j["report_hostname"] = options.report_hostname;
+  if (!options.operation_name_override.empty()) {
+    j["operation_name_override"] = options.operation_name_override;
+  }
+
+  return j.dump();
 }
 
 }  // namespace opentracing

--- a/test/integration/nginx/Dockerfile
+++ b/test/integration/nginx/Dockerfile
@@ -46,7 +46,7 @@ ENV LDFLAGS="-fPIC"
 
 
 RUN apt-get update && \
-  apt-get install -y git build-essential wget curl tar cmake libpcre3-dev zlib1g-dev
+  apt-get install -y git build-essential wget curl tar cmake libpcre3-dev
 
 WORKDIR /root
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
   "homepage": "https://github.com/DataDog/dd-opentracing-cpp",
   "description": "Datadog OpenTracing C++ Client",
   "dependencies": [
-    "zlib",
     "msgpack",
     "curl",
     "opentracing"


### PR DESCRIPTION
This is an identical replacement for https://github.com/DataDog/dd-opentracing-cpp/pull/221

Signatures got removed from my commits, I think by Github's in-browser merge conflict resolution tool.

I tried to rebase to add signatures to the commits, but I was getting conflicts at every step, for some reason.

Instead, this is `git diff master` relative to `david.goffredo/changes-for-nginx-module`, applied onto a new branch based off of `master` (`david.goffredo/changes-for-nginx-module-redux`).

Lesson learned.