### PR TITLE
SpanData is just data

### DIFF
--- a/src/span.cpp
+++ b/src/span.cpp
@@ -37,8 +37,6 @@ SpanData::SpanData(std::string type, std::string service, ot::string_view resour
       duration(duration),
       error(error) {}
 
-SpanData::SpanData() {}
-
 uint64_t SpanData::traceId() const { return trace_id; }
 uint64_t SpanData::spanId() const { return span_id; }
 

--- a/src/span.h
+++ b/src/span.h
@@ -20,26 +20,11 @@ typedef std::function<uint64_t()> IdProvider;  // See tracer.h
 // additionally contains handles to mechanisms it needs in order to implement
 // its methods (e.g. the logger, the tracer).  `SpanData` is just the data.
 struct SpanData {
-  ~SpanData() = default;
-
-  friend std::unique_ptr<SpanData> makeSpanData(std::string type, std::string service,
-                                                ot::string_view resource, std::string name,
-                                                uint64_t trace_id, uint64_t span_id,
-                                                uint64_t parent_id, int64_t start);
-
-  friend std::unique_ptr<SpanData> stubSpanData();
-
- protected:  // Can only be created in a unique_ptr (or in a subclassed test class).
   SpanData(std::string type, std::string service, ot::string_view resource, std::string name,
            uint64_t trace_id, uint64_t span_id, uint64_t parent_id, int64_t start,
            int64_t duration, int32_t error);
-  SpanData();
-  SpanData(const SpanData &) = default;
-  SpanData &operator=(const SpanData &) = delete;
-  SpanData(const SpanData &&) = delete;
-  SpanData &operator=(const SpanData &&) = delete;
+  SpanData() = default;
 
- public:
   std::string type;
   std::string service;
   std::string resource;

--- a/src/span.h
+++ b/src/span.h
@@ -29,12 +29,12 @@ struct SpanData {
   std::string service;
   std::string resource;
   std::string name;
-  uint64_t trace_id;
-  uint64_t span_id;
-  uint64_t parent_id;
-  int64_t start;
-  int64_t duration;
-  int32_t error;
+  uint64_t trace_id = 0;
+  uint64_t span_id = 0;
+  uint64_t parent_id = 0;
+  int64_t start = 0;
+  int64_t duration = 0;
+  int32_t error = 0;
   std::unordered_map<std::string, std::string> meta;  // Aka, tags.
   std::unordered_map<std::string, double> metrics;
 


### PR DESCRIPTION
I'm writing some unit tests involving `SpanData` and I think that restricting access to its constructors is unnecessary.