### PR TITLE
add a disclaimer to the documentation, in preparation for a release

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -254,6 +254,9 @@ order to prevent rejection by peers or other HTTP header policies.  This
 configuration option is that limit, in bytes.
 
 ### Span Sampling Rules
+_Note: Span sampling does not work yet, because the necessary Datadog Agent
+changes are not yet released._
+
 Span sampling rules allow spans to be sent to Datadog that otherwise would be
 dropped due to trace sampling.
 
@@ -266,6 +269,9 @@ Sampling][11] section of [sampling.md][6].
 - **Default value**: `[]`
 
 ### Span Sampling Rules File
+_Note: Span sampling does not work yet, because the necessary Datadog Agent
+changes are not yet released._
+
 Span sampling rules (see above) can be specified in their own file.  The value
 of the `DD_SPAN_SAMPLING_RULES_FILE` environment variable is the path to a file
 whose contents are the span sampling rules JSON array.

--- a/doc/sampling.md
+++ b/doc/sampling.md
@@ -122,6 +122,9 @@ environment variable.  Note that the environment variable overrides the
 
 Span Sampling
 -------------
+_Note: Span sampling does not work yet, because the necessary Datadog Agent
+changes are not yet released._
+
 Span sampling is used to select spans to keep even when the enclosing
 trace is dropped.
 

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -156,6 +156,9 @@ struct TracerOptions {
   // serialized tags allowed.  Trace-wide tags whose serialized length exceeds
   // this limit are not propagated.
   uint64_t tags_header_size = 512;
+  // Note about `span_sampling_rules`: Span sampling does not work yet, because
+  // the necessary Datadog Agent changes are not yet released.
+  //
   // Rule-based span sampling, which is distinct from rule-based trace
   // sampling, is used to determine which spans to keep, if any, when trace
   // sampling decides to drop the trace.


### PR DESCRIPTION
Span sampling rules are implemented, but the necessary changes to the Datadog Agent have yet to be released.

I want to produce a release of this library for the sake of `X-Datadog-Tags`.  Rather than base the release off of an older revision, I'll add this disclaimer to the documentation of the span sampling rules.