### PR TITLE
Tell CircleCI to build in the newly pushed 0.3.8 image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ default_environment: &default_environment
 defaults: &defaults
   working_directory: ~/dd-opentracing-cpp
   docker:
-    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_7
+    - image: datadog/docker-library:dd_opentracing_cpp_build_0_3_8
   resource_class: medium
   environment: *default_environment
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -5,7 +5,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.3.3";
+const std::string tracer_version = "v1.3.4";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version


### PR DESCRIPTION
The new image is based off of an older Ubuntu (18 instead of 20),
and rather than use the distribution's version of cmake, the image's
Dockerfile downloads a recent binary release of cmake instead.

I tested this locally, but haven't run the integration tests.  Let's see how CircleCI copes.