### PR TITLE
Always serialize X-Datadog-Tags

### DIFF
--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -78,12 +78,10 @@ class SpanBuffer {
   OptionalSamplingPriority generateSamplingPriority(const SpanData* span);
 
   // Return the serialization of the trace tags associated with the trace
-  // having the specified `trace_id`, or return an empty string if an error
-  // occurs.  Note that an empty string could mean either that there no tags or
-  // that an error occurred.  If an encoding error occurs, a corresponding
-  // `_dd.propagation_error` tag value will be added to the relevant trace's
-  // local root span.
-  std::string serializeTraceTags(uint64_t trace_id);
+  // having the specified `trace_id`, or return `nullptr` if an error occurs.
+  // If an encoding error occurs, a corresponding `_dd.propagation_error` tag
+  // value will be added to the relevant trace's local root span.
+  std::unique_ptr<std::string> serializeTraceTags(uint64_t trace_id);
 
   // Change the name of the service associated with the trace having the
   // specified `trace_id` to the specified `service_name`.

--- a/test/propagation_test.cpp
+++ b/test/propagation_test.cpp
@@ -900,7 +900,11 @@ TEST_CASE("propagated Datadog tags (x-datadog-tags)") {
       REQUIRE(result);
 
       const auto injected_json = nlohmann::json::parse(injected.str());
-      REQUIRE(injected_json.find("tags") == injected_json.end());
+      const auto tags = injected_json.find("tags");
+      // See <https://github.com/DataDog/dd-opentracing-cpp/issues/241>.
+      // Also, the redundant parentheses are required here because of the way
+      // Catch2 parses predicates (it's the "||").
+      REQUIRE((tags == injected_json.end() || *tags == ""));
 
       // Because the tags were omitted due to being oversized, there will be a
       // specific error tag on the local root span.


### PR DESCRIPTION
nginx-opentracing constrains us to set non-empty values for all propagation headers we wish to register in the "hack," or else a (harmless) error message will be printed to the nginx error log.

Propagating an empty header is silly, but will do no harm.  Nginx will not send it anyway, and Envoy is unlikely to be affected by these changes as we move to a new library there.