### PR TITLE
error tags

### DIFF
--- a/src/bool.cpp
+++ b/src/bool.cpp
@@ -1,4 +1,5 @@
-#include <string>
+#include "bool.h"
+
 #include <unordered_map>
 
 namespace datadog {
@@ -12,17 +13,27 @@ std::unordered_map<std::string, bool> conversions{
 }  // namespace
 
 bool stob(const std::string& str, bool fallback) {
-  if (str.empty()) {
-    return fallback;
+  switch (tribool(str)) {
+    case Tribool::True:
+      return true;
+    case Tribool::False:
+      return false;
+    default:
+      return fallback;
   }
-  auto result = conversions.find(str);
-  if (result == conversions.end()) {
-    return fallback;
-  }
-  return result->second;
 }
 
-bool isbool(const std::string& str) { return conversions.find(str) != conversions.end(); }
+bool isbool(const std::string& str) { return tribool(str) != Tribool::Neither; }
+
+Tribool tribool(bool value) { return value ? Tribool::True : Tribool::False; }
+
+Tribool tribool(const std::string& str) {
+  auto entry = conversions.find(str);
+  if (entry == conversions.end()) {
+    return Tribool::Neither;
+  }
+  return tribool(entry->second);
+}
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/bool.h
+++ b/src/bool.h
@@ -1,11 +1,18 @@
 #ifndef DD_OPENTRACING_BOOL_H
 #define DD_OPENTRACING_BOOL_H
 
+#include <string>
+
 namespace datadog {
 namespace opentracing {
 
 bool stob(const std::string& str, bool fallback);
 bool isbool(const std::string& str);
+
+enum class Tribool { False, True, Neither };
+
+Tribool tribool(const std::string&);
+Tribool tribool(bool);
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/span.cpp
+++ b/src/span.cpp
@@ -103,6 +103,33 @@ std::regex &PATH_MIXED_ALPHANUMERICS() {
       "\\d\\?]*[\\d-]+[^\\/]*))"};
   return r;
 }
+
+// Deduce `span.error` and "error.*" tag values from the set values of "error*"
+// tags.
+// See the error-related test SECTIONs in `span_test.cpp` for more information.
+void finish_error_tags(SpanData& span) {
+  const std::string error_details[] = {"error.msg", "error.stack", "error.type"};
+
+  const auto error_tag = span.meta.find(::ot::ext::error);
+  if (error_tag != span.meta.end()) {
+    if (error_tag->second == "" || !stob(error_tag->second, true)) {
+      span.error = 0;
+      span.meta.erase(error_tag);
+      for (const auto& tag_name : error_details) {
+        span.meta.erase(tag_name);
+      }
+      return;
+    }
+    span.error = 1;
+  }
+
+  for (const auto& tag_name : error_details) {
+    if (span.meta.count(tag_name)) {
+      span.error = 1;
+      span.meta.erase(::ot::ext::error);
+    }
+  }
+}
 }  // namespace
 
 // Imperfectly audits the data in a Span, removing some things that could cause information leaks
@@ -134,7 +161,6 @@ void Span::FinishWithOptions(
   span_->duration =
       std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time_).count();
   // Apply special tags.
-  // If we add any more cases; then abstract this. For now, KISS.
   auto tag = span_->meta.find(tags::span_type);
   if (tag != span_->meta.end()) {
     span_->type = tag->second;
@@ -150,19 +176,7 @@ void Span::FinishWithOptions(
     span_->service = tag->second;
     span_->meta.erase(tag);
   }
-  tag = span_->meta.find(::ot::ext::error);
-  if (tag != span_->meta.end()) {
-    // tag->second is the JSON-serialized value of the variadic type given to SetTag.
-    // Errors can be a flag or a detailed message.
-    // Empty or false-y values indicate no error.
-    // Any other value will mark the span to indicate an error occured.
-    if (tag->second == "" || !stob(tag->second, true)) {
-      span_->error = 0;
-    } else {
-      span_->error = 1;
-    }
-    // Don't erase the tag, in case it is populated with interesting information.
-  }
+  finish_error_tags(*span_);
   tag = span_->meta.find(tags::analytics_event);
   if (tag != span_->meta.end()) {
     // tag->second is the JSON-serialized value of the variadic type given to SetTag.

--- a/src/span.cpp
+++ b/src/span.cpp
@@ -107,7 +107,7 @@ std::regex &PATH_MIXED_ALPHANUMERICS() {
 // Deduce `span.error` and "error.*" tag values from the set values of "error*"
 // tags.
 // See the error-related test SECTIONs in `span_test.cpp` for more information.
-void finish_error_tags(SpanData& span) {
+void finish_error_tags(SpanData &span) {
   const std::string error_details[] = {"error.msg", "error.stack", "error.type"};
 
   const auto error_tag = span.meta.find(::ot::ext::error);
@@ -115,7 +115,7 @@ void finish_error_tags(SpanData& span) {
     if (error_tag->second == "" || !stob(error_tag->second, true)) {
       span.error = 0;
       span.meta.erase(error_tag);
-      for (const auto& tag_name : error_details) {
+      for (const auto &tag_name : error_details) {
         span.meta.erase(tag_name);
       }
       return;
@@ -123,7 +123,7 @@ void finish_error_tags(SpanData& span) {
     span.error = 1;
   }
 
-  for (const auto& tag_name : error_details) {
+  for (const auto &tag_name : error_details) {
     if (span.meta.count(tag_name)) {
       span.error = 1;
       span.meta.erase(::ot::ext::error);

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -307,11 +307,11 @@ TEST_CASE("span") {
     };
 
     auto error_tag_test_case = GENERATE(values<ErrorTagTestCase>({
-        {"0", 0, "0"},
-        {0, 0, "0"},
+        {"0", 0, ""},
+        {0, 0, ""},
         {"", 0, ""},
-        {"false", 0, "false"},
-        {false, 0, "false"},
+        {"false", 0, ""},
+        {false, 0, ""},
         {"1", 1, "1"},
         {1, 1, "1"},
         {"any random truth-ish string or value lol", 1,
@@ -372,17 +372,21 @@ TEST_CASE("span") {
           //   error    .msg    .stack   .type      error    .msg     .stack   .type
           //   ----------------------------------  --------------------------------------------
           // No error tags means no error.
-          {0, {nullptr, nullptr, nullptr, nullptr}, {nullptr, nullptr, nullptr, nullptr}, false},
+          {0,  {nullptr, nullptr, nullptr, nullptr}, {nullptr, nullptr, nullptr, nullptr}, false},
           // Setting any of the "error.*" tags sets the error property.
-          {1, {nullptr, "dummy", nullptr, nullptr}, {nullptr, "dummy", nullptr, nullptr}, true},
-          {2, {nullptr, nullptr, "dummy", nullptr}, {nullptr, nullptr, "dummy", nullptr}, true},
-          {3, {nullptr, nullptr, nullptr, "dummy"}, {nullptr, nullptr, nullptr, "dummy"}, true},
+          {1,  {nullptr, "dummy", nullptr, nullptr}, {nullptr, "dummy", nullptr, nullptr}, true},
+          {2,  {nullptr, nullptr, "dummy", nullptr}, {nullptr, nullptr, "dummy", nullptr}, true},
+          {3,  {nullptr, nullptr, nullptr, "dummy"}, {nullptr, nullptr, nullptr, "dummy"}, true},
           // "error" without "error.*" leaves just "error".
-          {4, {"true",  nullptr, nullptr, nullptr}, {"true",  nullptr, nullptr, nullptr}, true},
+          {4,  {"true",  nullptr, nullptr, nullptr}, {"true",  nullptr, nullptr, nullptr}, true},
           // Setting "error.*" unsets "error", but keeps the error property.
-          {5, {"true",  "dummy", nullptr, nullptr}, {nullptr, "dummy", nullptr, nullptr}, true},
-          {6, {"true",  nullptr, "dummy", nullptr}, {nullptr, nullptr, "dummy", nullptr}, true},
-          {7, {"true",  nullptr, nullptr, "dummy"}, {nullptr, nullptr, nullptr, "dummy"}, true},
+          {5,  {"true",  "dummy", nullptr, nullptr}, {nullptr, "dummy", nullptr, nullptr}, true},
+          {6,  {"true",  nullptr, "dummy", nullptr}, {nullptr, nullptr, "dummy", nullptr}, true},
+          {7,  {"true",  nullptr, nullptr, "dummy"}, {nullptr, nullptr, nullptr, "dummy"}, true},
+          // If "error" is falsy, then "error" and "error.*" tags are removed, and no error.
+          {8,  {"false", "dummy", "dummy", "dummy"}, {nullptr, nullptr, nullptr, nullptr}, false},
+          {9,  {"0",     "dummy", "dummy", "dummy"}, {nullptr, nullptr, nullptr, nullptr}, false},
+          {10, {"",      "dummy", "dummy", "dummy"}, {nullptr, nullptr, nullptr, nullptr}, false},
     }));
     // clang-format on
 

--- a/test/span_test.cpp
+++ b/test/span_test.cpp
@@ -359,9 +359,9 @@ TEST_CASE("span") {
     };
 
     struct Case {
-      int index;        // for debugging
-      ErrorTags before; // before span finishes
-      ErrorTags after;  // after span finishes
+      int index;         // for debugging
+      ErrorTags before;  // before span finishes
+      ErrorTags after;   // after span finishes
       bool error_property_after;
     };
 
@@ -395,7 +395,7 @@ TEST_CASE("span") {
     if (test_case.before.error != nullptr) {
       span.SetTag("error", test_case.before.error.get<std::string>());
     }
-    if (test_case.before.msg!= nullptr) {
+    if (test_case.before.msg != nullptr) {
       span.SetTag("error.msg", test_case.before.msg.get<std::string>());
     }
     if (test_case.before.stack != nullptr) {


### PR DESCRIPTION
This revision makes spans aware of the `error.msg`, `error.stack`, and `error.type` tags.

These changes grew out of Andrew Glaude's investigation of compatibility between the C++ tracer and "error tracking": https://docs.datadoghq.com/tracing/error_tracking/.

The new behavior is best summarized by the table of test cases in the added `SECTION` of [test/span_test.cpp](https://github.com/DataDog/dd-opentracing-cpp/compare/david.goffredo/error-tags?expand=1#diff-2bcf8accc397819e5fd6c3bb04a96fbbd9d63479238b27861f4bfb1b2234f2a5).

@ajgajg1134 (he's on vacation) FYI.

Also, when these changes are finalized, we'll want to update these docs: https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/cpp/#set-errors-on-a-span