### PR TITLE
mention the Agent version required for span sampling

### DIFF
--- a/doc/sampling.md
+++ b/doc/sampling.md
@@ -122,8 +122,7 @@ environment variable.  Note that the environment variable overrides the
 
 Span Sampling
 -------------
-_Note: Span sampling does not work yet, because the necessary Datadog Agent
-changes are not yet released._
+_Note: Span sampling requires version 7.40 of the Datadog Agent or a more recent version._
 
 Span sampling is used to select spans to keep even when the enclosing
 trace is dropped.

--- a/include/datadog/opentracing.h
+++ b/include/datadog/opentracing.h
@@ -156,8 +156,8 @@ struct TracerOptions {
   // serialized tags allowed.  Trace-wide tags whose serialized length exceeds
   // this limit are not propagated.
   uint64_t tags_header_size = 512;
-  // Note about `span_sampling_rules`: Span sampling does not work yet, because
-  // the necessary Datadog Agent changes are not yet released.
+  // Note about `span_sampling_rules`: Span sampling requires version 7.40 of
+  // the Datadog Agent or a more recent version.
   //
   // Rule-based span sampling, which is distinct from rule-based trace
   // sampling, is used to determine which spans to keep, if any, when trace


### PR DESCRIPTION
The next release of the Datadog Agent, 7.40, will contain the code necessary for span sampling rules to have their intended effect.

This PR updates our documentation accordingly.