### PR TITLE
bump version number to future version

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -5,7 +5,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.3.6";
+const std::string tracer_version = "v1.3.7";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version


### PR DESCRIPTION
Per today's v1.3.6 release.