### PR TITLE
Add DD_TAGS colon edge case test

### DIFF
--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -68,11 +68,9 @@ std::map<std::string, std::string> keyvalues(std::string text, char itemsep, cha
       keyfound = false;
       continue;
     }
-    if (ch == itemsep) {
-      if (!keyfound) {
-        keyfound = true;
-        continue;
-      }
+    if (ch == itemsep && !keyfound) {
+      keyfound = true;
+      continue;
     }
     assignchar(ch);
   }

--- a/src/tracer_options.cpp
+++ b/src/tracer_options.cpp
@@ -69,8 +69,10 @@ std::map<std::string, std::string> keyvalues(std::string text, char itemsep, cha
       continue;
     }
     if (ch == itemsep) {
-      keyfound = true;
-      continue;
+      if (!keyfound) {
+        keyfound = true;
+        continue;
+      }
     }
     assignchar(ch);
   }

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE("tracer options from environment variables") {
         {"DD_TRACE_REPORT_HOSTNAME", "true"},
         {"DD_TRACE_ANALYTICS_ENABLED", "true"},
         {"DD_TRACE_ANALYTICS_SAMPLE_RATE", "0.5"},
-        {"DD_TAGS", "host:my-host-name,region:us-east-1,datacenter:us,partition:5"},
+        {"DD_TAGS", "host:my-host-name,region:us-east-1,datacenter:us,a.b_c:a:b,partition:5"},
         {"DD_TRACE_RATE_LIMIT", "200"},
         {"DD_TRACE_SAMPLE_RATE", "0.7"}},
        TracerOptions{
@@ -101,6 +101,7 @@ TEST_CASE("tracer options from environment variables") {
                {"host", "my-host-name"},
                {"region", "us-east-1"},
                {"datacenter", "us"},
+               {"a.b_c", "a:b"},
                {"partition", "5"},
            },                                 // tags
            "test-version v0.0.1",             // version

--- a/test/tracer_options_test.cpp
+++ b/test/tracer_options_test.cpp
@@ -21,6 +21,15 @@ std::ostream &operator<<(std::ostream &stream,
 }  // namespace opentracing
 }  // namespace datadog
 
+namespace std {
+
+std::ostream &operator<<(std::ostream &stream,
+                         const std::pair<const std::string, std::string> &key_value) {
+  return stream << key_value.first << " → " << key_value.second;
+}
+
+}  // namespace std
+
 void requireTracerOptionsResultsMatch(const ot::expected<TracerOptions, std::string> &lhs,
                                       const ot::expected<TracerOptions, std::string> &rhs) {
   // One is an error, the other not.


### PR DESCRIPTION
Colons are allowed in Datadog tags. This adds a test case ensuring support.

https://docs.datadoghq.com/getting_started/tagging/#define-tags