### PR TITLE
David.goffredo/dummy span behavior

### DIFF
--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -61,7 +61,8 @@ void SpanBuffer::finishSpan(std::unique_ptr<SpanData> span) {
   }
 }
 
-void SpanBuffer::unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator trace_iter) {
+void SpanBuffer::unbufferAndWriteTrace(
+    std::unordered_map<uint64_t, PendingTrace>::iterator trace_iter) {
   // `mutex_` must already be locked, and `trace_iter` must not be
   // `traces_.end()`.
   auto& trace = trace_iter->second;

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -53,20 +53,17 @@ void SpanBuffer::finishSpan(std::unique_ptr<SpanData> span) {
     logger_->Log(LogLevel::error, "A Span that was not registered was submitted to SpanBuffer");
     return;
   }
-  uint64_t trace_id = span->traceId();
   trace.finished_spans->push_back(std::move(span));
   if (trace.finished_spans->size() == trace.all_spans.size()) {
     generateSamplingPriorityImpl(trace.finished_spans->back().get());
     trace.finish(span_sampler_.get());
-    unbufferAndWriteTrace(trace_id);
+    unbufferAndWriteTrace(trace_iter);
   }
 }
 
-void SpanBuffer::unbufferAndWriteTrace(uint64_t trace_id) {
-  auto trace_iter = traces_.find(trace_id);
-  if (trace_iter == traces_.end()) {
-    return;
-  }
+void SpanBuffer::unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator trace_iter) {
+  // `mutex_` must already be locked, and `trace_iter` must not be
+  // `traces_.end()`.
   auto& trace = trace_iter->second;
   if (options_.enabled) {
     writer_->write(std::move(trace.finished_spans));

--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -126,7 +126,7 @@ class SpanBuffer {
  protected:
   // Exists to make it easy for a subclass (ie, our testing mock) to override on-trace-finish
   // behaviour.
-  virtual void unbufferAndWriteTrace(uint64_t trace_id);
+  virtual void unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator trace_iter);
 
   std::unordered_map<uint64_t, PendingTrace> traces_;
   SpanBufferOptions options_;

--- a/src/span_buffer.h
+++ b/src/span_buffer.h
@@ -126,7 +126,8 @@ class SpanBuffer {
  protected:
   // Exists to make it easy for a subclass (ie, our testing mock) to override on-trace-finish
   // behaviour.
-  virtual void unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator trace_iter);
+  virtual void unbufferAndWriteTrace(
+      std::unordered_map<uint64_t, PendingTrace>::iterator trace_iter);
 
   std::unordered_map<uint64_t, PendingTrace> traces_;
   SpanBufferOptions options_;

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -241,6 +241,13 @@ Tracer::Tracer(TracerOptions options, std::shared_ptr<Writer> writer,
                         options.service, traceTagsPropagationMaxLength(options, *logger_)});
 }
 
+Tracer::~Tracer() {
+  try {
+    Close();
+  } catch (...) {
+  }
+}
+
 std::unique_ptr<ot::Span> Tracer::StartSpanWithOptions(ot::string_view operation_name,
                                                        const ot::StartSpanOptions &options) const
     noexcept try {

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -45,6 +45,9 @@ class Tracer : public ot::Tracer, public std::enable_shared_from_this<Tracer> {
 
   Tracer() = delete;
 
+  // Destructs tracer and flushes internal buffers
+  virtual ~Tracer();
+
   // Starts a new span.
   std::unique_ptr<ot::Span> StartSpanWithOptions(ot::string_view operation_name,
                                                  const ot::StartSpanOptions &options) const

--- a/test/integration/nginx/expected_tc1.json
+++ b/test/integration/nginx/expected_tc1.json
@@ -67,5 +67,22 @@
       "service": "nginx",
       "type": "web"
     }
+  ],
+  [
+    {
+      "error": 0,
+      "meta": {
+        "_dd.p.dm": "-4",
+        "operation": "dummySpan",
+        "sampling.priority": "0"
+      },
+      "metrics": {
+        "_sampling_priority_v1": -1
+      },
+      "name": "nginx.handle",
+      "resource": "dummySpan",
+      "service": "nginx",
+      "type": "web"
+    }
   ]
 ]

--- a/test/integration/nginx/nginx_integration_test.sh
+++ b/test/integration/nginx/nginx_integration_test.sh
@@ -203,7 +203,7 @@ run_nginx
 curl -s localhost/get_error/ 1> /tmp/curl_log.txt
 
 GOT=$(get_n_traces 1)
-ERROR=$(echo "$GOT" | jq '.[] | .[] | .error')
+ERROR=$(echo "$GOT" | jq '.[] | map(select(.resource != "dummySpan")) | .[] | .error')
 
 if ! [ "$ERROR" = "1" ]
 then

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -231,7 +231,7 @@ struct MockBuffer : public SpanBuffer {
                    SpanBufferOptions{true, "localhost", std::nan(""), service, tags_header_size}) {
   }
 
-  void unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator) override {
+  void unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator) override{
       // Haha NOPE.
       // Leave the trace inside the traces map instead of deleting it.
   };

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -231,7 +231,7 @@ struct MockBuffer : public SpanBuffer {
                    SpanBufferOptions{true, "localhost", std::nan(""), service, tags_header_size}) {
   }
 
-  void unbufferAndWriteTrace(uint64_t /* trace_id */) override{
+  void unbufferAndWriteTrace(std::unordered_map<uint64_t, PendingTrace>::iterator) override {
       // Haha NOPE.
       // Leave the trace inside the traces map instead of deleting it.
   };


### PR DESCRIPTION
This is my fiddling with #249.

Flushing the tracer on destruction causes nginx's master process to send a trace within the time the integration test waits for a certain number of traces.

I still haven't figured out how to get the integration tests running on my new machine's Docker setup, so I'll use CI via this pull request instead.