### PR TITLE
Fix examples to work with most recent release.

### DIFF
--- a/examples/cpp-tracing/compiled-in/Dockerfile
+++ b/examples/cpp-tracing/compiled-in/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && \
-  apt-get -y install build-essential cmake wget
+  DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils
 
 # Download and install dd-opentracing-cpp library.
 RUN get_latest_release() { \
@@ -15,7 +15,7 @@ RUN get_latest_release() { \
   # Download and install the correct version of opentracing-cpp, & other deps.
   ../scripts/install_dependencies.sh && \
   cmake .. && \
-  make && \
+  make -j "$(nproc)" && \
   make install
 
 COPY tracer_example.cpp .

--- a/examples/cpp-tracing/compiled-in/build_and_run_example.sh
+++ b/examples/cpp-tracing/compiled-in/build_and_run_example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -z "$DD_API_KEY" ]
 then
@@ -10,4 +10,7 @@ DD_API_KEY=${DD_API_KEY} docker-compose up \
   --build \
   --abort-on-container-exit \
   --exit-code-from dd-opentracing-cpp-example
-docker rm dd-agent
+
+rcode=$?
+docker-compose rm --force dd-agent
+exit "$rcode"

--- a/examples/cpp-tracing/compiled-in/docker-compose.yml
+++ b/examples/cpp-tracing/compiled-in/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
       - 'DD_APM_ENABLED=true'
+      - 'DD_LOG_LEVEL=error'
       - DD_API_KEY
     image: 'datadog/agent'

--- a/examples/cpp-tracing/dynamic-loading/Dockerfile
+++ b/examples/cpp-tracing/dynamic-loading/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && \
-  apt-get -y install build-essential cmake wget
+  DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils
 
 # Download and install OpenTracing-cpp
 RUN get_latest_release() { \
@@ -14,7 +14,7 @@ RUN get_latest_release() { \
   tar zxvf opentracing-cpp.tar.gz -C ./opentracing-cpp/ --strip-components=1 && \
   cd opentracing-cpp/.build && \
   cmake .. && \
-  make && \
+  make -j "$(nproc)" && \
   make install && \
   # Install dd-opentracing-cpp shared plugin.
   wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz && \
@@ -23,7 +23,7 @@ RUN get_latest_release() { \
 
 COPY tracer_example.cpp .
 
-RUN g++ -std=c++11 -o tracer_example tracer_example.cpp -lopentracing
+RUN g++ -std=c++14 -o tracer_example tracer_example.cpp -lopentracing
 # Add /usr/local/lib to LD_LIBRARY_PATH
 RUN ldconfig
 

--- a/examples/cpp-tracing/dynamic-loading/build_and_run_example.sh
+++ b/examples/cpp-tracing/dynamic-loading/build_and_run_example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -z "$DD_API_KEY" ]
 then
@@ -10,4 +10,7 @@ DD_API_KEY=${DD_API_KEY} docker-compose up \
   --build \
   --abort-on-container-exit \
   --exit-code-from dd-opentracing-cpp-example
-docker rm dd-agent
+
+rcode=$?
+docker-compose rm --force dd-agent
+exit "$rcode"

--- a/examples/cpp-tracing/dynamic-loading/docker-compose.yml
+++ b/examples/cpp-tracing/dynamic-loading/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
       - 'DD_APM_ENABLED=true'
+      - 'DD_LOG_LEVEL=error'
       - DD_API_KEY
     image: 'datadog/agent'
     ports:

--- a/examples/cpp-tracing/unix-domain-socket/Dockerfile
+++ b/examples/cpp-tracing/unix-domain-socket/Dockerfile
@@ -1,6 +1,6 @@
 from ubuntu:20.04
 
-run apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget
+run apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils
 
 # Download and install the latest release of the Datadog C++ tracer library.
 copy bin/install-latest-dd-opentracing-cpp .

--- a/examples/cpp-tracing/unix-domain-socket/bin/install-latest-dd-opentracing-cpp
+++ b/examples/cpp-tracing/unix-domain-socket/bin/install-latest-dd-opentracing-cpp
@@ -17,5 +17,5 @@ cd dd-opentracing-cpp/.build
 # Download and install the correct version of opentracing-cpp, & other deps.
 ../scripts/install_dependencies.sh
 cmake ..
-make
+make -j "$(nproc)"
 make install

--- a/examples/cpp-tracing/unix-domain-socket/bin/run
+++ b/examples/cpp-tracing/unix-domain-socket/bin/run
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+if [ -z "$DD_API_KEY" ]; then
+  >&2 echo "Please set environment variable DD_API_KEY"
+  exit 1
+fi
+
 testdir=$(dirname "$(dirname "$(realpath "$0")")")
 
-docker-compose --file "$testdir/docker-compose.yaml" up --build --remove-orphans
+docker-compose --file "$testdir/docker-compose.yaml" up \
+  --build \
+  --remove-orphans \
+  --abort-on-container-exit \
+  --exit-code-from dd-opentracing-cpp-example-unix-domain-socket

--- a/examples/cpp-tracing/unix-domain-socket/docker-compose.yaml
+++ b/examples/cpp-tracing/unix-domain-socket/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
       - DD_APM_ENABLED=true
+      - DD_LOG_LEVEL=error
       - DD_API_KEY
       - DD_APM_RECEIVER_SOCKET=/var/run/datadog-sockets/datadog-agent.sock
     image: 'datadog/agent'

--- a/examples/nginx-tracing/docker-compose.yml
+++ b/examples/nginx-tracing/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - DD_API_KEY
       - DD_APM_ENABLED=true
+      - DD_LOG_LEVEL=error
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_AC_EXCLUDE=name:datadog-agent


### PR DESCRIPTION
The CMake version required to build dd-opentracing-cpp was increased recently, but the examples/ were not updated to use a version of Ubuntu that had the required version.

This commit updates the Docker base images used in the examples, as well as tweaks the examples to build faster and a couple of other conveniences.