### PR TITLE
log an error when the agent responds with a non-success HTTP status

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,7 +5,7 @@ set -e
 
 usage() {
     argv0="$0"
-    
+
     cat <<END_USAGE
 format.sh - format Datadog C++ source code
 

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -177,9 +177,10 @@ void AgentWriter::startWriting(std::unique_ptr<Handle> handle) {
                 trace_encoder_->handleResponse(handle->getResponse());
               }
             }
-            // if `success == false`, then `postTraces` will have already logged
-            // an error.
           }
+          // If `success == false`, then `postTraces` will have already logged
+          // an error.
+
           // Let thread calling 'flush' know that we're done flushing.
           {
             std::unique_lock<std::mutex> lock(mutex_);

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -170,10 +170,10 @@ void AgentWriter::startWriting(std::unique_ptr<Handle> handle) {
                             "following body of length "
                          << body.size() << ": " << body;
               logger_->Log(LogLevel::error, diagnostic.str());
-            } else if (response_status < 200 || response_status >= 300) {
+            } else if (response_status != 200) {
               const std::string body = handle->getResponse();
               std::ostringstream diagnostic;
-              diagnostic << "Datadog Agent returned response with non-success HTTP status "
+              diagnostic << "Datadog Agent returned response with unexpected HTTP status "
                          << response_status << " and the following body of length " << body.size()
                          << ": " << body;
               logger_->Log(LogLevel::error, diagnostic.str());

--- a/src/agent_writer.cpp
+++ b/src/agent_writer.cpp
@@ -160,7 +160,7 @@ void AgentWriter::startWriting(std::unique_ptr<Handle> handle) {
           bool success = retryFiniteOnFail(
               [&]() { return AgentWriter::postTraces(handle, headers, payload, logger_); });
           // Sending could fail. If it succeeds, then the HTTP response status
-          // could indicate an error or a successful response.
+          // could indicate an error or success.
           if (success) {
             int response_status;
             const CURLcode rc = handle->getResponseStatus(response_status);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -97,13 +97,13 @@ CURLcode CurlHandle::perform() {
 
 std::string CurlHandle::getError() { return std::string(curl_error_buffer_); }
 std::string CurlHandle::getResponse() { return response_buffer_.str(); }
-CURLcode CurlHandle::getResponseStatus(int& status) {
-  long raw;
-  CURLcode result = curl_easy_getinfo(handle_, CURLINFO_RESPONSE_CODE, &raw);
-  if (result == CURLE_OK) {
-    status = static_cast<int>(raw);
-  }
-  return result;
+int CurlHandle::getResponseStatus() {
+  long raw = 0;
+  // As of November 2003 (libcurl version 7.10.8), fetching the response code
+  // will not return an error.
+  // If there is no response code to return, then zero will be set.
+  (void)curl_easy_getinfo(handle_, CURLINFO_RESPONSE_CODE, &raw);
+  return static_cast<int>(raw);
 }
 
 }  // namespace opentracing

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -97,6 +97,14 @@ CURLcode CurlHandle::perform() {
 
 std::string CurlHandle::getError() { return std::string(curl_error_buffer_); }
 std::string CurlHandle::getResponse() { return response_buffer_.str(); }
+CURLcode CurlHandle::getResponseStatus(int& status) {
+  long raw;
+  CURLcode result = curl_easy_getinfo(handle_, CURLINFO_RESPONSE_CODE, &raw);
+  if (result == CURLE_OK) {
+    status = static_cast<int>(raw);
+  }
+  return result;
+}
 
 }  // namespace opentracing
 }  // namespace datadog

--- a/src/transport.h
+++ b/src/transport.h
@@ -24,6 +24,7 @@ class Handle {
   virtual CURLcode perform() = 0;
   virtual std::string getError() = 0;
   virtual std::string getResponse() = 0;
+  virtual CURLcode getResponseStatus(int& status) = 0;
 };
 
 // A Handle that uses real curl to really send things. Not thread-safe.
@@ -39,6 +40,7 @@ class CurlHandle : public Handle {
   CURLcode perform() override;
   std::string getError() override;
   std::string getResponse() override;
+  CURLcode getResponseStatus(int& status) override;
 
  private:
   // For things that need cleaning up if the constructor fails as well as on destruction.

--- a/src/transport.h
+++ b/src/transport.h
@@ -24,7 +24,10 @@ class Handle {
   virtual CURLcode perform() = 0;
   virtual std::string getError() = 0;
   virtual std::string getResponse() = 0;
-  virtual CURLcode getResponseStatus(int& status) = 0;
+  // Return the HTTP status of the response received, or return zero if no
+  // response was received or if there is no HTTP status associated with the
+  // response.
+  virtual int getResponseStatus() = 0;
 };
 
 // A Handle that uses real curl to really send things. Not thread-safe.
@@ -40,7 +43,7 @@ class CurlHandle : public Handle {
   CURLcode perform() override;
   std::string getError() override;
   std::string getResponse() override;
-  CURLcode getResponseStatus(int& status) override;
+  int getResponseStatus() override;
 
  private:
   // For things that need cleaning up if the constructor fails as well as on destruction.

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -194,15 +194,15 @@ TEST_CASE("writer") {
 
     writer.flush(std::chrono::seconds(10));
     REQUIRE(logger->records.size() != 0);
-    // The logged error diagnostic will say that there was not response status.
+    // The logged error diagnostic will say that there was no response status.
     REQUIRE_THAT(logger->records.back().message, Contains("response without an HTTP status"));
 
-    // HTTP statuses outside of [200, 300) indicate an error.
+    // HTTP statuses other than 200 are unexpected.
     std::vector<int> statuses;
     for (int i = 100; i < 200; ++i) {
       statuses.push_back(i);
     }
-    for (int i = 300; i < 600; ++i) {
+    for (int i = 201; i < 600; ++i) {
       statuses.push_back(i);
     }
     auto status = GENERATE_COPY(from_range(statuses));

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -196,14 +196,14 @@ TEST_CASE("writer") {
 
   SECTION("bad handle causes constructor to fail") {
     std::unique_ptr<MockHandle> handle_ptr{new MockHandle{}};
-    handle_ptr->setopt_rcode = CURLE_OPERATION_TIMEDOUT;
+    handle_ptr->rcode = CURLE_OPERATION_TIMEDOUT;
     REQUIRE_THROWS(AgentWriter{std::move(handle_ptr), only_send_traces_when_we_flush,
                                max_queued_traces, disable_retry, "hostname", 6319, "",
                                std::make_shared<RulesSampler>(), std::make_shared<MockLogger>()});
   }
 
   SECTION("handle failure during post") {
-    handle->setopt_rcode = CURLE_OPERATION_TIMEDOUT;
+    handle->rcode = CURLE_OPERATION_TIMEDOUT;
     writer.write(make_trace(
         {TestSpanData{"web", "service", "service.name", "resource", 1, 1, 0, 69, 420, 0}}));
     // Redirect stderr so the test logs don't look like a failure.
@@ -211,7 +211,7 @@ TEST_CASE("writer") {
     REQUIRE(logger->records.back().message ==
             "Error setting agent request size: Timeout was reached");
     // Dropped all spans.
-    handle->setopt_rcode = CURLE_OK;
+    handle->rcode = CURLE_OK;
     REQUIRE(handle->getTraces()->size() == 0);
   }
 

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -196,14 +196,14 @@ TEST_CASE("writer") {
 
   SECTION("bad handle causes constructor to fail") {
     std::unique_ptr<MockHandle> handle_ptr{new MockHandle{}};
-    handle_ptr->rcode = CURLE_OPERATION_TIMEDOUT;
+    handle_ptr->setopt_rcode = CURLE_OPERATION_TIMEDOUT;
     REQUIRE_THROWS(AgentWriter{std::move(handle_ptr), only_send_traces_when_we_flush,
                                max_queued_traces, disable_retry, "hostname", 6319, "",
                                std::make_shared<RulesSampler>(), std::make_shared<MockLogger>()});
   }
 
   SECTION("handle failure during post") {
-    handle->rcode = CURLE_OPERATION_TIMEDOUT;
+    handle->setopt_rcode = CURLE_OPERATION_TIMEDOUT;
     writer.write(make_trace(
         {TestSpanData{"web", "service", "service.name", "resource", 1, 1, 0, 69, 420, 0}}));
     // Redirect stderr so the test logs don't look like a failure.
@@ -211,7 +211,7 @@ TEST_CASE("writer") {
     REQUIRE(logger->records.back().message ==
             "Error setting agent request size: Timeout was reached");
     // Dropped all spans.
-    handle->rcode = CURLE_OK;
+    handle->setopt_rcode = CURLE_OK;
     REQUIRE(handle->getTraces()->size() == 0);
   }
 

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -184,6 +184,38 @@ TEST_CASE("writer") {
     REQUIRE(sampler->config == "");
   }
 
+  SECTION("handle error responses") {
+    using Catch::Matchers::Contains;
+
+    // HTTP status zero indicates "no status."
+    handle->response_status = 0;
+    writer.write(make_trace(
+        {TestSpanData{"web", "service", "resource", "service.name", 1, 1, 0, 69, 420, 0}}));
+
+    writer.flush(std::chrono::seconds(10));
+    REQUIRE(logger->records.size() != 0);
+    // The logged error diagnostic will say that there was not response status.
+    REQUIRE_THAT(logger->records.back().message, Contains("response without an HTTP status"));
+
+    // HTTP statuses outside of [200, 300) indicate an error.
+    std::vector<int> statuses;
+    for (int i = 100; i < 200; ++i) {
+      statuses.push_back(i);
+    }
+    for (int i = 300; i < 600; ++i) {
+      statuses.push_back(i);
+    }
+    auto status = GENERATE_COPY(from_range(statuses));
+    handle->response_status = status;
+    writer.write(make_trace(
+        {TestSpanData{"web", "service", "resource", "service.name", 1, 1, 0, 69, 420, 0}}));
+
+    writer.flush(std::chrono::seconds(10));
+    REQUIRE(logger->records.size() != 0);
+    // The logged error diagnostic will contain the response status.
+    REQUIRE_THAT(logger->records.back().message, Contains(" " + std::to_string(status) + " "));
+  }
+
   SECTION("queue does not grow indefinitely") {
     for (uint64_t i = 0; i < 30; i++) {  // Only 25 actually get written.
       writer.write(make_trace(

--- a/test/agent_writer_test.cpp
+++ b/test/agent_writer_test.cpp
@@ -197,6 +197,18 @@ TEST_CASE("writer") {
     // The logged error diagnostic will say that there was no response status.
     REQUIRE_THAT(logger->records.back().message, Contains("response without an HTTP status"));
 
+    // HTTP status 200 with an empty body means that the response really should
+    // be 429 "too many requests," but the Agent is not configured to return
+    // that status and instead uses 200.
+    handle->response_status = 200;
+    writer.write(make_trace(
+        {TestSpanData{"web", "service", "resource", "service.name", 1, 1, 0, 69, 420, 0}}));
+
+    writer.flush(std::chrono::seconds(10));
+    REQUIRE(logger->records.size() != 0);
+    // The logged error diagnostic will mention the lack of response.
+    REQUIRE_THAT(logger->records.back().message, Contains("response without a body"));
+
     // HTTP statuses other than 200 are unexpected.
     std::vector<int> statuses;
     for (int i = 100; i < 200; ++i) {

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -275,7 +275,7 @@ struct MockHandle : public Handle {
 
   CURLcode setopt(CURLoption key, const char* value) override {
     std::unique_lock<std::mutex> lock(mutex);
-    if (setopt_rcode == CURLE_OK) {
+    if (rcode == CURLE_OK) {
       // We might have null characters if it's the POST data, thanks msgpack!
       if (key == CURLOPT_POSTFIELDS && options.find(CURLOPT_POSTFIELDSIZE) != options.end()) {
         long len = std::stol(options.find(CURLOPT_POSTFIELDSIZE)->second);
@@ -284,23 +284,23 @@ struct MockHandle : public Handle {
         options[key] = std::string(value);
       }
     }
-    return setopt_rcode;
+    return rcode;
   }
 
   CURLcode setopt(CURLoption key, long value) override {
     std::unique_lock<std::mutex> lock(mutex);
-    if (setopt_rcode == CURLE_OK) {
+    if (rcode == CURLE_OK) {
       options[key] = std::to_string(value);
     }
-    return setopt_rcode;
+    return rcode;
   }
 
   CURLcode setopt(CURLoption key, size_t value) override {
     std::unique_lock<std::mutex> lock(mutex);
-    if (setopt_rcode == CURLE_OK) {
+    if (rcode == CURLE_OK) {
       options[key] = std::to_string(value);
     }
-    return setopt_rcode;
+    return rcode;
   }
 
   void setHeaders(std::map<std::string, std::string> headers_) override {
@@ -331,12 +331,9 @@ struct MockHandle : public Handle {
     return response;
   }
 
-  CURLcode getResponseStatus(int& status) override {
+  int getResponseStatus() override {
     std::unique_lock<std::mutex> lock(mutex);
-    if (get_response_status_rcode == CURLE_OK) {
-      status = response_status;
-    }
-    return get_response_status_rcode;
+    return response_status;
   }
 
   // Note, this returns any traces that have been added to the request - NOT traces that have been
@@ -360,8 +357,7 @@ struct MockHandle : public Handle {
   std::string error = "";
   std::string response = "";
   int response_status = 200;
-  CURLcode setopt_rcode = CURLE_OK;
-  CURLcode get_response_status_rcode = CURLE_OK;
+  CURLcode rcode = CURLE_OK;
   std::atomic<bool>* is_destructed = nullptr;
   // Each time an perform is called, the next perform_result is used to determine if it
   // succeeds or fails. Loops. Default is for all operations to succeed.


### PR DESCRIPTION
Currently, the `AgentWriter` passes all response bodies to the `AgentHttpEncoder`. The `AgentHttpEncoder` then interprets the body as a JSON object. However, when the HTTP response status does not indicate success, the agent does not return a JSON response body.

This revision logs an error whenever a non-success HTTP response status is delivered by the agent.