### PR TITLE
bump version::tracer_version to future version v1.3.8

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -5,7 +5,7 @@
 namespace datadog {
 namespace version {
 
-const std::string tracer_version = "v1.3.7";
+const std::string tracer_version = "v1.3.8";
 const std::string cpp_version = std::to_string(__cplusplus);
 
 }  // namespace version


### PR DESCRIPTION
This is to unblock the CI check affecting #262 