### PR TITLE
Fix findings from running semgrep

### DIFF
--- a/examples/cpp-tracing/compiled-in/Dockerfile
+++ b/examples/cpp-tracing/compiled-in/Dockerfile
@@ -24,4 +24,5 @@ RUN g++ -std=c++14 -o tracer_example tracer_example.cpp -I/dd-opentracing-cpp/de
 # Add /usr/local/lib to LD_LIBRARY_PATH
 RUN ldconfig
 
+USER nobody
 CMD sleep 5 && ./tracer_example && sleep 25

--- a/examples/cpp-tracing/compiled-in/Dockerfile
+++ b/examples/cpp-tracing/compiled-in/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils
+  DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils jq
 
 # Download and install dd-opentracing-cpp library.
 RUN get_latest_release() { \
-  wget -qO- "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'; \
+  wget -qO- "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name; \
   } && \
   VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)" && \
   wget https://github.com/DataDog/dd-opentracing-cpp/archive/${VERSION}.tar.gz -O dd-opentracing-cpp.tar.gz && \

--- a/examples/cpp-tracing/dynamic-loading/Dockerfile
+++ b/examples/cpp-tracing/dynamic-loading/Dockerfile
@@ -1,23 +1,18 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils
+  DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake ca-certificates wget coreutils jq
 
 # Download and install OpenTracing-cpp
-RUN get_latest_release() { \
-  wget -qO- "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'; \
-  } && \
-  DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)" && \
-  OPENTRACING_VERSION="$(get_latest_release opentracing/opentracing-cpp)" && \
-  wget https://github.com/opentracing/opentracing-cpp/archive/${OPENTRACING_VERSION}.tar.gz -O opentracing-cpp.tar.gz && \
+RUN wget https://github.com/opentracing/opentracing-cpp/archive/v1.6.0.tar.gz -O opentracing-cpp.tar.gz && \
   mkdir -p opentracing-cpp/.build && \
   tar zxvf opentracing-cpp.tar.gz -C ./opentracing-cpp/ --strip-components=1 && \
   cd opentracing-cpp/.build && \
   cmake .. && \
   make -j "$(nproc)" && \
-  make install && \
-  # Install dd-opentracing-cpp shared plugin.
-  wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz && \
+  make install
+# Install dd-opentracing-cpp plugin
+RUN wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/v1.3.7/linux-amd64-libdd_opentracing_plugin.so.gz && \
   gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
 
 
@@ -27,4 +22,5 @@ RUN g++ -std=c++14 -o tracer_example tracer_example.cpp -lopentracing
 # Add /usr/local/lib to LD_LIBRARY_PATH
 RUN ldconfig
 
+USER nobody
 CMD sleep 5 && ./tracer_example && sleep 25

--- a/examples/cpp-tracing/dynamic-loading/docker-compose.yml
+++ b/examples/cpp-tracing/dynamic-loading/docker-compose.yml
@@ -17,5 +17,3 @@ services:
       - 'DD_LOG_LEVEL=error'
       - DD_API_KEY
     image: 'datadog/agent'
-    ports:
-        - "127.0.0.1:8126:8126"

--- a/examples/cpp-tracing/unix-domain-socket/Dockerfile
+++ b/examples/cpp-tracing/unix-domain-socket/Dockerfile
@@ -1,6 +1,6 @@
 from ubuntu:20.04
 
-run apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils
+run apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake wget coreutils jq
 
 # Download and install the latest release of the Datadog C++ tracer library.
 copy bin/install-latest-dd-opentracing-cpp .

--- a/examples/cpp-tracing/unix-domain-socket/bin/install-latest-dd-opentracing-cpp
+++ b/examples/cpp-tracing/unix-domain-socket/bin/install-latest-dd-opentracing-cpp
@@ -3,7 +3,7 @@
 set -e
 
 get_latest_release() {
-  wget -qO- "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+  wget -qO- "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name
 }
 
 VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"

--- a/examples/nginx-tracing/Dockerfile
+++ b/examples/nginx-tracing/Dockerfile
@@ -2,11 +2,11 @@
 FROM nginx:1.17.3
 
 RUN apt-get update && \
-  apt-get install -y wget tar
+  apt-get install -y wget tar jq
 
 # Install nginx-opentracing
 RUN get_latest_release() { \
-  wget -qO- "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'; \
+  wget -qO- "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name; \
   } && \
   NGINX_VERSION=`nginx -v 2>&1 > /dev/null | sed -E "s/^.*nginx\/(.*)/\\1/"`&& \
   OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)" && \


### PR DESCRIPTION
As part of an audit, a couple of relatively benign changes were suggested.

```
semgrep --config "p/owasp-top-ten" --config "p/cwe-top-25" --config "p/r2c-security-audit" --text
```

For simplicity, a couple of additional changes were made
- install specific version of dd-opentracing-cpp and opentracing-cpp instead of using get_latest_release
- remove port binding from docker-compose